### PR TITLE
added ubuntu 12.10 package dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Prerequisite for installation
 * Platform: OSX 10.8.3+ or CentOS 6+, Ubuntu 12.10+ (Although Windows is not tested, NemakiWare is basically platform-agnostic).
 * Package management system, yum (CentOS), Homebrew/Mac Port (Mac), apt-get (Ubuntu) as you like
 
+### On Ubuntu 
+```bash
+sudo apt-get install curl vim git openjdk-6-jdk maven ruby1.9.1 ruby1.9.1-dev sqlite3 libsqlite3-dev -y
+```
+
 Installation
 ------
 ### Clone the repository


### PR DESCRIPTION
wanted to make it easy to copy / paste what one would need prior to installing the software for ubuntu.  I used this vagrant https://github.com/bdossantos/puppet-module-couchdb project to get couch installed easily -- I also changed the vm from precise64 to quantal64 locally to meet the 12.10 minimum requirement for Nemaki (didn't feel like forking the project)

``` ruby
  config.vm.box = "quantal64"
  config.vm.box_url = "https://github.com/downloads/roderik/VagrantQuantal64Box/quantal64.box"
```
