### PR TITLE
chown copied files to user who is installing this software

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -10,6 +10,10 @@ echo "Copy tracking files"
 cp -f ../nemakisolr/src/main/webapp/WEB-INF/classes/tracking.properties.template ../nemakisolr/src/main/webapp/WEB-INF/classes/tracking.properties
 cp -f ../nemakishare/config/latest_change_token.yml.template ../nemakishare/config/latest_change_token.yml
 
+#Change ownership to user running the software
+chown $(whoami):$(whoami) ../nemakisolr/src/main/webapp/WEB-INF/classes/tracking.properties
+chown $(whoami):$(whoami) ../nemakishare/config/latest_change_token.yml
+
 
 #Client's bundle install
 echo "Install NemakiWare client dependencies"


### PR DESCRIPTION
after running `sudo sh setup.sh`

``` bash
cp -f ../nemakisolr/src/main/webapp/WEB-INF/classes/tracking.properties.template ../nemakisolr/src/main/webapp/WEB-INF/classes/tracking.properties
cp -f ../nemakishare/config/latest_change_token.yml.template ../nemakishare/config/latest_change_token.yml
```

those two files became owned by root
