### PR TITLE
feat(api-v1): Add OpenAPI v1 foundation with Swagger, DTOs, error handling, auth/CORS filters and repository resource

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -760,6 +760,83 @@
 			<artifactId>jakarta.jws-api</artifactId>
 			<version>3.0.0</version>
 		</dependency>
+
+		<!-- OpenAPI/Swagger Dependencies for REST API v1 -->
+		<!-- Swagger Core for OpenAPI 3.0 annotations and specification -->
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-jaxrs2-jakarta</artifactId>
+			<version>2.2.25</version>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-annotations-jakarta</artifactId>
+			<version>2.2.25</version>
+		</dependency>
+
+		<!-- REST Assured for API testing -->
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Swagger Request Validator for OpenAPI compliance testing -->
+		<dependency>
+			<groupId>com.atlassian.oai</groupId>
+			<artifactId>swagger-request-validator-restassured</artifactId>
+			<version>2.40.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Apache Olingo for OData 4.0 support -->
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-server-core</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-server-api</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-commons-core</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-commons-api</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+
+		<!-- Apache Olingo Client for OData testing -->
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-client-core</artifactId>
+			<version>4.10.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-client-api</artifactId>
+			<version>4.10.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Jakarta Validation for request validation -->
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>8.0.1.Final</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/ApiJacksonProvider.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/ApiJacksonProvider.java
@@ -1,0 +1,37 @@
+package jp.aegif.nemaki.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class ApiJacksonProvider implements ContextResolver<ObjectMapper> {
+    
+    private final ObjectMapper objectMapper;
+    
+    public ApiJacksonProvider() {
+        objectMapper = new ObjectMapper();
+        
+        // Configure for ISO 8601 date format
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        
+        // Pretty print for readability
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        
+        // Don't fail on unknown properties (forward compatibility)
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        
+        // Include non-null values only
+        objectMapper.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL);
+    }
+    
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return objectMapper;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
@@ -36,7 +36,7 @@ import jakarta.ws.rs.ApplicationPath;
         )
     ),
     servers = {
-        @Server(url = "/core", description = "NemakiWare Server")
+        @Server(url = "/core/api/v1", description = "NemakiWare REST API v1")
     },
     tags = {
         @Tag(name = "repositories", description = "Repository management operations"),

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
@@ -81,8 +81,8 @@ public class ApiV1Application extends ResourceConfig {
         // Register authentication filter
         register(jp.aegif.nemaki.api.v1.filter.ApiAuthenticationFilter.class);
         
-        // Register CORS filter
-        register(jp.aegif.nemaki.api.v1.filter.ApiCorsFilter.class);
+        // Note: CORS is handled by SimpleCorsFilter in web.xml to avoid duplicate headers
+        // Do NOT register ApiCorsFilter here as it would cause double CORS header application
         
         // Enable Jersey-Spring bridge for automatic DI
         property("jersey.config.server.provider.classnames", 

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
@@ -1,0 +1,97 @@
+package jp.aegif.nemaki.api.v1;
+
+import java.util.logging.Logger;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.spring.SpringLifecycleListener;
+import org.glassfish.jersey.server.spring.SpringComponentProvider;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.jackson.JacksonFeature;
+
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.ws.rs.ApplicationPath;
+
+@ApplicationPath("/api/v1")
+@OpenAPIDefinition(
+    info = @Info(
+        title = "NemakiWare REST API",
+        version = "1.0.0",
+        description = "OpenAPI 3.0 compliant REST API for NemakiWare CMIS Repository. " +
+                      "This API provides full access to CMIS operations including object management, " +
+                      "versioning, navigation, and query capabilities.",
+        contact = @Contact(
+            name = "NemakiWare Project",
+            url = "https://github.com/aegif/NemakiWare"
+        ),
+        license = @License(
+            name = "GNU AGPL v3",
+            url = "https://www.gnu.org/licenses/agpl-3.0.html"
+        )
+    ),
+    servers = {
+        @Server(url = "/core", description = "NemakiWare Server")
+    },
+    tags = {
+        @Tag(name = "repositories", description = "Repository management operations"),
+        @Tag(name = "objects", description = "Generic object operations (canonical endpoint)"),
+        @Tag(name = "documents", description = "Document-specific operations including versioning"),
+        @Tag(name = "folders", description = "Folder-specific operations and navigation"),
+        @Tag(name = "types", description = "Type definition management"),
+        @Tag(name = "acl", description = "Access control list operations"),
+        @Tag(name = "query", description = "CMIS query operations"),
+        @Tag(name = "users", description = "User management operations"),
+        @Tag(name = "groups", description = "Group management operations"),
+        @Tag(name = "auth", description = "Authentication operations")
+    }
+)
+public class ApiV1Application extends ResourceConfig {
+    
+    private static final Logger logger = Logger.getLogger(ApiV1Application.class.getName());
+
+    public ApiV1Application() {
+        logger.info("=== Initializing NemakiWare API v1 Application ===");
+        
+        // Enable Jersey-Spring integration
+        register(SpringLifecycleListener.class);
+        register(SpringComponentProvider.class);
+        
+        // Enable multipart support for content stream uploads
+        register(MultiPartFeature.class);
+        
+        // Enable JSON processing with Jackson
+        register(JacksonFeature.class);
+        
+        // Register custom Jackson provider for unified ObjectMapper
+        register(jp.aegif.nemaki.api.v1.ApiJacksonProvider.class);
+        
+        // Register OpenAPI/Swagger resource for /openapi.json endpoint
+        register(OpenApiResource.class);
+        
+        // Register exception mappers for RFC 7807 compliant error responses
+        register(jp.aegif.nemaki.api.v1.exception.ApiExceptionMapper.class);
+        register(jp.aegif.nemaki.api.v1.exception.ValidationExceptionMapper.class);
+        
+        // Register authentication filter
+        register(jp.aegif.nemaki.api.v1.filter.ApiAuthenticationFilter.class);
+        
+        // Register CORS filter
+        register(jp.aegif.nemaki.api.v1.filter.ApiCorsFilter.class);
+        
+        // Enable Jersey-Spring bridge for automatic DI
+        property("jersey.config.server.provider.classnames", 
+                "org.glassfish.jersey.server.spring.SpringLifecycleListener," +
+                "org.glassfish.jersey.server.spring.scope.RequestContextFilter");
+        
+        // Enable automatic package scanning for REST resources
+        packages("jp.aegif.nemaki.api.v1.resource");
+        
+        logger.info("=== NemakiWare API v1 Application initialized successfully ===");
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiException.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiException.java
@@ -1,0 +1,108 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+public class ApiException extends RuntimeException {
+    
+    private final ProblemDetail problemDetail;
+    
+    public ApiException(ProblemDetail problemDetail) {
+        super(problemDetail.getDetail());
+        this.problemDetail = problemDetail;
+    }
+    
+    public ApiException(ProblemDetail problemDetail, Throwable cause) {
+        super(problemDetail.getDetail(), cause);
+        this.problemDetail = problemDetail;
+    }
+    
+    public ProblemDetail getProblemDetail() {
+        return problemDetail;
+    }
+    
+    public int getStatus() {
+        return problemDetail.getStatus();
+    }
+    
+    public static ApiException invalidArgument(String detail) {
+        return new ApiException(ProblemDetail.invalidArgument(detail));
+    }
+    
+    public static ApiException invalidArgument(String detail, String instance) {
+        return new ApiException(ProblemDetail.invalidArgument(detail, instance));
+    }
+    
+    public static ApiException unauthorized(String detail) {
+        return new ApiException(ProblemDetail.unauthorized(detail));
+    }
+    
+    public static ApiException unauthorized(String detail, String instance) {
+        return new ApiException(ProblemDetail.unauthorized(detail, instance));
+    }
+    
+    public static ApiException permissionDenied(String detail) {
+        return new ApiException(ProblemDetail.permissionDenied(detail));
+    }
+    
+    public static ApiException permissionDenied(String detail, String instance) {
+        return new ApiException(ProblemDetail.permissionDenied(detail, instance));
+    }
+    
+    public static ApiException objectNotFound(String objectId, String repositoryId) {
+        return new ApiException(ProblemDetail.objectNotFound(objectId, repositoryId));
+    }
+    
+    public static ApiException objectNotFound(String objectId, String repositoryId, String instance) {
+        return new ApiException(ProblemDetail.objectNotFound(objectId, repositoryId, instance));
+    }
+    
+    public static ApiException typeNotFound(String typeId, String repositoryId) {
+        return new ApiException(ProblemDetail.typeNotFound(typeId, repositoryId));
+    }
+    
+    public static ApiException repositoryNotFound(String repositoryId) {
+        return new ApiException(ProblemDetail.repositoryNotFound(repositoryId));
+    }
+    
+    public static ApiException userNotFound(String userId, String repositoryId) {
+        return new ApiException(ProblemDetail.userNotFound(userId, repositoryId));
+    }
+    
+    public static ApiException groupNotFound(String groupId, String repositoryId) {
+        return new ApiException(ProblemDetail.groupNotFound(groupId, repositoryId));
+    }
+    
+    public static ApiException conflict(String detail) {
+        return new ApiException(ProblemDetail.conflict(detail));
+    }
+    
+    public static ApiException conflict(String detail, String instance) {
+        return new ApiException(ProblemDetail.conflict(detail, instance));
+    }
+    
+    public static ApiException contentAlreadyExists(String objectId) {
+        return new ApiException(ProblemDetail.contentAlreadyExists(objectId));
+    }
+    
+    public static ApiException versionConflict(String objectId, String expectedToken, String actualToken) {
+        return new ApiException(ProblemDetail.versionConflict(objectId, expectedToken, actualToken));
+    }
+    
+    public static ApiException constraintViolation(String detail) {
+        return new ApiException(ProblemDetail.constraintViolation(detail));
+    }
+    
+    public static ApiException constraintViolation(String detail, String instance) {
+        return new ApiException(ProblemDetail.constraintViolation(detail, instance));
+    }
+    
+    public static ApiException internalError(String detail) {
+        return new ApiException(ProblemDetail.internalError(detail));
+    }
+    
+    public static ApiException internalError(String detail, Throwable cause) {
+        return new ApiException(ProblemDetail.internalError(detail), cause);
+    }
+    
+    public static ApiException serviceUnavailable(String detail) {
+        return new ApiException(ProblemDetail.serviceUnavailable(detail));
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiExceptionMapper.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiExceptionMapper.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.apache.chemistry.opencmis.commons.exceptions.CmisBaseException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisPermissionDeniedException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisInvalidArgumentException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisConstraintException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisContentAlreadyExistsException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisUpdateConflictException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisUnauthorizedException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Provider
+public class ApiExceptionMapper implements ExceptionMapper<Throwable> {
+    
+    private static final Logger logger = Logger.getLogger(ApiExceptionMapper.class.getName());
+    private static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+    
+    @Override
+    public Response toResponse(Throwable exception) {
+        ProblemDetail problemDetail;
+        
+        if (exception instanceof ApiException) {
+            problemDetail = ((ApiException) exception).getProblemDetail();
+        } else if (exception instanceof CmisObjectNotFoundException) {
+            problemDetail = ProblemDetail.objectNotFound(
+                    extractObjectId((CmisObjectNotFoundException) exception),
+                    "unknown");
+        } else if (exception instanceof CmisPermissionDeniedException) {
+            problemDetail = ProblemDetail.permissionDenied(exception.getMessage());
+        } else if (exception instanceof CmisUnauthorizedException) {
+            problemDetail = ProblemDetail.unauthorized(exception.getMessage());
+        } else if (exception instanceof CmisInvalidArgumentException) {
+            problemDetail = ProblemDetail.invalidArgument(exception.getMessage());
+        } else if (exception instanceof CmisConstraintException) {
+            problemDetail = ProblemDetail.constraintViolation(exception.getMessage());
+        } else if (exception instanceof CmisContentAlreadyExistsException) {
+            problemDetail = ProblemDetail.contentAlreadyExists("unknown");
+            problemDetail.setDetail(exception.getMessage());
+        } else if (exception instanceof CmisUpdateConflictException) {
+            problemDetail = ProblemDetail.conflict(exception.getMessage());
+        } else if (exception instanceof CmisBaseException) {
+            CmisBaseException cmisEx = (CmisBaseException) exception;
+            problemDetail = mapCmisException(cmisEx);
+        } else if (exception instanceof IllegalArgumentException) {
+            problemDetail = ProblemDetail.invalidArgument(exception.getMessage());
+        } else {
+            logger.log(Level.SEVERE, "Unexpected exception in API", exception);
+            problemDetail = ProblemDetail.internalError(
+                    "An unexpected error occurred: " + exception.getMessage());
+        }
+        
+        return Response.status(problemDetail.getStatus())
+                .type(PROBLEM_JSON_MEDIA_TYPE)
+                .entity(problemDetail)
+                .build();
+    }
+    
+    private ProblemDetail mapCmisException(CmisBaseException cmisEx) {
+        int httpStatus = cmisEx.getCode() != null ? cmisEx.getCode().intValue() : 500;
+        String errorName = cmisEx.getExceptionName();
+        
+        if (httpStatus >= 400 && httpStatus < 500) {
+            if (httpStatus == 400) {
+                return ProblemDetail.invalidArgument(cmisEx.getMessage());
+            } else if (httpStatus == 401) {
+                return ProblemDetail.unauthorized(cmisEx.getMessage());
+            } else if (httpStatus == 403) {
+                return ProblemDetail.permissionDenied(cmisEx.getMessage());
+            } else if (httpStatus == 404) {
+                return new ProblemDetail("not-found", "Not Found", 404, cmisEx.getMessage());
+            } else if (httpStatus == 409) {
+                return ProblemDetail.conflict(cmisEx.getMessage());
+            } else {
+                return new ProblemDetail("client-error", errorName, httpStatus, cmisEx.getMessage());
+            }
+        } else {
+            return ProblemDetail.internalError(cmisEx.getMessage());
+        }
+    }
+    
+    private String extractObjectId(CmisObjectNotFoundException ex) {
+        String message = ex.getMessage();
+        if (message != null && message.contains("'")) {
+            int start = message.indexOf("'");
+            int end = message.indexOf("'", start + 1);
+            if (end > start) {
+                return message.substring(start + 1, end);
+            }
+        }
+        return "unknown";
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ProblemDetail.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ProblemDetail.java
@@ -1,0 +1,208 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.net.URI;
+import java.util.Map;
+
+@Schema(description = "RFC 7807 Problem Details for HTTP APIs")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProblemDetail {
+    
+    private static final String BASE_TYPE_URI = "https://nemakiware.org/errors/";
+    
+    @Schema(description = "A URI reference that identifies the problem type",
+            example = "https://nemakiware.org/errors/object-not-found")
+    @JsonProperty("type")
+    private String type;
+    
+    @Schema(description = "A short, human-readable summary of the problem type",
+            example = "Object Not Found")
+    @JsonProperty("title")
+    private String title;
+    
+    @Schema(description = "The HTTP status code",
+            example = "404")
+    @JsonProperty("status")
+    private int status;
+    
+    @Schema(description = "A human-readable explanation specific to this occurrence of the problem",
+            example = "The object with ID 'OBJECT_ID' was not found in repository 'bedroom'")
+    @JsonProperty("detail")
+    private String detail;
+    
+    @Schema(description = "A URI reference that identifies the specific occurrence of the problem",
+            example = "/api/v1/repositories/bedroom/objects/OBJECT_ID")
+    @JsonProperty("instance")
+    private String instance;
+    
+    @Schema(description = "Additional properties specific to the error type")
+    @JsonProperty("extensions")
+    private Map<String, Object> extensions;
+    
+    public ProblemDetail() {
+    }
+    
+    public ProblemDetail(String type, String title, int status, String detail) {
+        this.type = BASE_TYPE_URI + type;
+        this.title = title;
+        this.status = status;
+        this.detail = detail;
+    }
+    
+    public ProblemDetail(String type, String title, int status, String detail, String instance) {
+        this(type, title, status, detail);
+        this.instance = instance;
+    }
+    
+    public static ProblemDetail invalidArgument(String detail) {
+        return new ProblemDetail("invalid-argument", "Invalid Argument", 400, detail);
+    }
+    
+    public static ProblemDetail invalidArgument(String detail, String instance) {
+        return new ProblemDetail("invalid-argument", "Invalid Argument", 400, detail, instance);
+    }
+    
+    public static ProblemDetail unauthorized(String detail) {
+        return new ProblemDetail("unauthorized", "Unauthorized", 401, detail);
+    }
+    
+    public static ProblemDetail unauthorized(String detail, String instance) {
+        return new ProblemDetail("unauthorized", "Unauthorized", 401, detail, instance);
+    }
+    
+    public static ProblemDetail permissionDenied(String detail) {
+        return new ProblemDetail("permission-denied", "Permission Denied", 403, detail);
+    }
+    
+    public static ProblemDetail permissionDenied(String detail, String instance) {
+        return new ProblemDetail("permission-denied", "Permission Denied", 403, detail, instance);
+    }
+    
+    public static ProblemDetail objectNotFound(String objectId, String repositoryId) {
+        String detail = String.format("The object with ID '%s' was not found in repository '%s'", objectId, repositoryId);
+        return new ProblemDetail("object-not-found", "Object Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail objectNotFound(String objectId, String repositoryId, String instance) {
+        String detail = String.format("The object with ID '%s' was not found in repository '%s'", objectId, repositoryId);
+        return new ProblemDetail("object-not-found", "Object Not Found", 404, detail, instance);
+    }
+    
+    public static ProblemDetail typeNotFound(String typeId, String repositoryId) {
+        String detail = String.format("The type with ID '%s' was not found in repository '%s'", typeId, repositoryId);
+        return new ProblemDetail("type-not-found", "Type Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail repositoryNotFound(String repositoryId) {
+        String detail = String.format("The repository '%s' was not found", repositoryId);
+        return new ProblemDetail("repository-not-found", "Repository Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail userNotFound(String userId, String repositoryId) {
+        String detail = String.format("The user with ID '%s' was not found in repository '%s'", userId, repositoryId);
+        return new ProblemDetail("user-not-found", "User Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail groupNotFound(String groupId, String repositoryId) {
+        String detail = String.format("The group with ID '%s' was not found in repository '%s'", groupId, repositoryId);
+        return new ProblemDetail("group-not-found", "Group Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail conflict(String detail) {
+        return new ProblemDetail("conflict", "Conflict", 409, detail);
+    }
+    
+    public static ProblemDetail conflict(String detail, String instance) {
+        return new ProblemDetail("conflict", "Conflict", 409, detail, instance);
+    }
+    
+    public static ProblemDetail contentAlreadyExists(String objectId) {
+        String detail = String.format("Content already exists for object '%s'", objectId);
+        return new ProblemDetail("content-already-exists", "Content Already Exists", 409, detail);
+    }
+    
+    public static ProblemDetail versionConflict(String objectId, String expectedToken, String actualToken) {
+        String detail = String.format("Version conflict for object '%s': expected changeToken '%s' but found '%s'", 
+                objectId, expectedToken, actualToken);
+        return new ProblemDetail("version-conflict", "Version Conflict", 409, detail);
+    }
+    
+    public static ProblemDetail constraintViolation(String detail) {
+        return new ProblemDetail("constraint-violation", "Constraint Violation", 422, detail);
+    }
+    
+    public static ProblemDetail constraintViolation(String detail, String instance) {
+        return new ProblemDetail("constraint-violation", "Constraint Violation", 422, detail, instance);
+    }
+    
+    public static ProblemDetail internalError(String detail) {
+        return new ProblemDetail("internal-error", "Internal Server Error", 500, detail);
+    }
+    
+    public static ProblemDetail internalError(String detail, String instance) {
+        return new ProblemDetail("internal-error", "Internal Server Error", 500, detail, instance);
+    }
+    
+    public static ProblemDetail serviceUnavailable(String detail) {
+        return new ProblemDetail("service-unavailable", "Service Unavailable", 503, detail);
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public int getStatus() {
+        return status;
+    }
+    
+    public void setStatus(int status) {
+        this.status = status;
+    }
+    
+    public String getDetail() {
+        return detail;
+    }
+    
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+    
+    public String getInstance() {
+        return instance;
+    }
+    
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+    
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+    
+    public void setExtensions(Map<String, Object> extensions) {
+        this.extensions = extensions;
+    }
+    
+    public ProblemDetail withExtension(String key, Object value) {
+        if (this.extensions == null) {
+            this.extensions = new java.util.HashMap<>();
+        }
+        this.extensions.put(key, value);
+        return this;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ValidationExceptionMapper.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ValidationExceptionMapper.java
@@ -1,0 +1,49 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Provider
+public class ValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+    
+    private static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+    
+    @Override
+    public Response toResponse(ConstraintViolationException exception) {
+        List<Map<String, String>> violations = exception.getConstraintViolations().stream()
+                .map(this::mapViolation)
+                .collect(Collectors.toList());
+        
+        String detail = violations.stream()
+                .map(v -> v.get("field") + ": " + v.get("message"))
+                .collect(Collectors.joining("; "));
+        
+        ProblemDetail problemDetail = ProblemDetail.invalidArgument(detail);
+        problemDetail.withExtension("violations", violations);
+        
+        return Response.status(400)
+                .type(PROBLEM_JSON_MEDIA_TYPE)
+                .entity(problemDetail)
+                .build();
+    }
+    
+    private Map<String, String> mapViolation(ConstraintViolation<?> violation) {
+        String propertyPath = violation.getPropertyPath().toString();
+        String field = propertyPath.contains(".") 
+                ? propertyPath.substring(propertyPath.lastIndexOf('.') + 1)
+                : propertyPath;
+        
+        return Map.of(
+                "field", field,
+                "message", violation.getMessage(),
+                "invalidValue", String.valueOf(violation.getInvalidValue())
+        );
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiAuthenticationFilter.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.filter;
+
+import jakarta.annotation.Priority;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.logging.Logger;
+
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class ApiAuthenticationFilter implements ContainerRequestFilter {
+    
+    private static final Logger logger = Logger.getLogger(ApiAuthenticationFilter.class.getName());
+    private static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+    
+    @Context
+    private HttpServletRequest httpServletRequest;
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String path = requestContext.getUriInfo().getPath();
+        
+        // Allow access to OpenAPI spec without authentication
+        if (path.endsWith("/openapi.json") || path.endsWith("/openapi.yaml")) {
+            return;
+        }
+        
+        // Allow access to auth endpoints without authentication
+        if (path.contains("/auth/login") || path.contains("/auth/saml") || path.contains("/auth/oidc")) {
+            return;
+        }
+        
+        // Check if CallContext is already set by the existing authentication filter
+        Object callContext = httpServletRequest.getAttribute("CallContext");
+        if (callContext != null) {
+            // Already authenticated by existing filter chain
+            return;
+        }
+        
+        // Check for Authorization header
+        String authHeader = requestContext.getHeaderString("Authorization");
+        if (authHeader == null || authHeader.isEmpty()) {
+            abortWithUnauthorized(requestContext, "Authentication required. Please provide credentials.");
+            return;
+        }
+        
+        // The actual authentication is handled by the existing AuthenticationFilter
+        // This filter just ensures the request has proper authentication headers
+        // and provides RFC 7807 compliant error responses
+        
+        if (authHeader.startsWith("Basic ")) {
+            // Basic auth - validate format
+            try {
+                String credentials = authHeader.substring(6);
+                byte[] decoded = Base64.getDecoder().decode(credentials);
+                String decodedStr = new String(decoded);
+                if (!decodedStr.contains(":")) {
+                    abortWithUnauthorized(requestContext, "Invalid Basic authentication format");
+                    return;
+                }
+            } catch (IllegalArgumentException e) {
+                abortWithUnauthorized(requestContext, "Invalid Basic authentication encoding");
+                return;
+            }
+        } else if (authHeader.startsWith("Bearer ")) {
+            // Bearer token - validate format
+            String token = authHeader.substring(7);
+            if (token.isEmpty()) {
+                abortWithUnauthorized(requestContext, "Empty Bearer token");
+                return;
+            }
+        } else {
+            abortWithUnauthorized(requestContext, "Unsupported authentication scheme. Use Basic or Bearer.");
+            return;
+        }
+        
+        // Authentication will be completed by the existing filter chain
+    }
+    
+    private void abortWithUnauthorized(ContainerRequestContext requestContext, String message) {
+        ProblemDetail problemDetail = ProblemDetail.unauthorized(message, requestContext.getUriInfo().getPath());
+        
+        requestContext.abortWith(
+                Response.status(Response.Status.UNAUTHORIZED)
+                        .header("WWW-Authenticate", "Basic realm=\"NemakiWare\", Bearer realm=\"NemakiWare\"")
+                        .type(PROBLEM_JSON_MEDIA_TYPE)
+                        .entity(problemDetail)
+                        .build()
+        );
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiCorsFilter.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiCorsFilter.java
@@ -1,0 +1,52 @@
+package jp.aegif.nemaki.api.v1.filter;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import java.io.IOException;
+
+@Provider
+@PreMatching
+@Priority(Priorities.HEADER_DECORATOR)
+public class ApiCorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        // Handle preflight requests
+        if (requestContext.getMethod().equalsIgnoreCase("OPTIONS")) {
+            requestContext.abortWith(
+                    Response.ok()
+                            .header("Access-Control-Allow-Origin", "*")
+                            .header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+                            .header("Access-Control-Allow-Headers", 
+                                    "Origin, Content-Type, Accept, Authorization, X-Requested-With, " +
+                                    "X-Change-Token, X-Overwrite-Flag, Content-Disposition")
+                            .header("Access-Control-Max-Age", "86400")
+                            .header("Access-Control-Expose-Headers", 
+                                    "Content-Disposition, X-Total-Count, X-Accessible-Count, " +
+                                    "ETag, Location, Link, Deprecation, Sunset")
+                            .build()
+            );
+        }
+    }
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        // Add CORS headers to all responses
+        responseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
+        responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+        responseContext.getHeaders().add("Access-Control-Allow-Headers", 
+                "Origin, Content-Type, Accept, Authorization, X-Requested-With, " +
+                "X-Change-Token, X-Overwrite-Flag, Content-Disposition");
+        responseContext.getHeaders().add("Access-Control-Expose-Headers", 
+                "Content-Disposition, X-Total-Count, X-Accessible-Count, " +
+                "ETag, Location, Link, Deprecation, Sunset");
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/PropertyValue.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/PropertyValue.java
@@ -1,0 +1,236 @@
+package jp.aegif.nemaki.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Property value with type information for dynamic CMIS properties")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PropertyValue {
+    
+    @Schema(description = "Property value. Can be string, number, boolean, or array for multi-valued properties",
+            example = "invoice-2026-001.pdf")
+    @JsonProperty("value")
+    private Object value;
+    
+    @Schema(description = "Property type identifier",
+            allowableValues = {"string", "boolean", "integer", "decimal", "datetime", "uri", "id", "html"},
+            example = "string")
+    @JsonProperty("type")
+    private String type;
+    
+    @Schema(description = "Human-readable display name for the property",
+            example = "Name")
+    @JsonProperty("displayName")
+    private String displayName;
+    
+    @Schema(description = "Cardinality of the property",
+            allowableValues = {"single", "multi"},
+            example = "single")
+    @JsonProperty("cardinality")
+    private String cardinality;
+    
+    @Schema(description = "Property definition ID",
+            example = "cmis:name")
+    @JsonProperty("propertyDefinitionId")
+    private String propertyDefinitionId;
+    
+    @Schema(description = "Local name of the property",
+            example = "name")
+    @JsonProperty("localName")
+    private String localName;
+    
+    @Schema(description = "Query name for use in CMIS queries",
+            example = "cmis:name")
+    @JsonProperty("queryName")
+    private String queryName;
+    
+    public PropertyValue() {
+    }
+    
+    public PropertyValue(Object value, String type) {
+        this.value = value;
+        this.type = type;
+        this.cardinality = (value instanceof List) ? "multi" : "single";
+    }
+    
+    public PropertyValue(Object value, String type, String displayName) {
+        this(value, type);
+        this.displayName = displayName;
+    }
+    
+    public static PropertyValue ofString(String value) {
+        return new PropertyValue(value, "string");
+    }
+    
+    public static PropertyValue ofString(String value, String displayName) {
+        return new PropertyValue(value, "string", displayName);
+    }
+    
+    public static PropertyValue ofBoolean(Boolean value) {
+        return new PropertyValue(value, "boolean");
+    }
+    
+    public static PropertyValue ofBoolean(Boolean value, String displayName) {
+        return new PropertyValue(value, "boolean", displayName);
+    }
+    
+    public static PropertyValue ofInteger(Long value) {
+        return new PropertyValue(value, "integer");
+    }
+    
+    public static PropertyValue ofInteger(Long value, String displayName) {
+        return new PropertyValue(value, "integer", displayName);
+    }
+    
+    public static PropertyValue ofDecimal(Double value) {
+        return new PropertyValue(value, "decimal");
+    }
+    
+    public static PropertyValue ofDecimal(Double value, String displayName) {
+        return new PropertyValue(value, "decimal", displayName);
+    }
+    
+    public static PropertyValue ofDatetime(String isoDateTime) {
+        return new PropertyValue(isoDateTime, "datetime");
+    }
+    
+    public static PropertyValue ofDatetime(String isoDateTime, String displayName) {
+        return new PropertyValue(isoDateTime, "datetime", displayName);
+    }
+    
+    public static PropertyValue ofId(String id) {
+        return new PropertyValue(id, "id");
+    }
+    
+    public static PropertyValue ofId(String id, String displayName) {
+        return new PropertyValue(id, "id", displayName);
+    }
+    
+    public static PropertyValue ofUri(String uri) {
+        return new PropertyValue(uri, "uri");
+    }
+    
+    public static PropertyValue ofUri(String uri, String displayName) {
+        return new PropertyValue(uri, "uri", displayName);
+    }
+    
+    public static PropertyValue ofHtml(String html) {
+        return new PropertyValue(html, "html");
+    }
+    
+    public static PropertyValue ofHtml(String html, String displayName) {
+        return new PropertyValue(html, "html", displayName);
+    }
+    
+    public static PropertyValue ofMultiString(List<String> values) {
+        PropertyValue pv = new PropertyValue(values, "string");
+        pv.setCardinality("multi");
+        return pv;
+    }
+    
+    public static PropertyValue ofMultiString(List<String> values, String displayName) {
+        PropertyValue pv = new PropertyValue(values, "string", displayName);
+        pv.setCardinality("multi");
+        return pv;
+    }
+    
+    public Object getValue() {
+        return value;
+    }
+    
+    public void setValue(Object value) {
+        this.value = value;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+    
+    public String getCardinality() {
+        return cardinality;
+    }
+    
+    public void setCardinality(String cardinality) {
+        this.cardinality = cardinality;
+    }
+    
+    public String getPropertyDefinitionId() {
+        return propertyDefinitionId;
+    }
+    
+    public void setPropertyDefinitionId(String propertyDefinitionId) {
+        this.propertyDefinitionId = propertyDefinitionId;
+    }
+    
+    public String getLocalName() {
+        return localName;
+    }
+    
+    public void setLocalName(String localName) {
+        this.localName = localName;
+    }
+    
+    public String getQueryName() {
+        return queryName;
+    }
+    
+    public void setQueryName(String queryName) {
+        this.queryName = queryName;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public String getStringValue() {
+        if (value == null) return null;
+        if (value instanceof String) return (String) value;
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            return list.isEmpty() ? null : String.valueOf(list.get(0));
+        }
+        return String.valueOf(value);
+    }
+    
+    public Long getIntegerValue() {
+        if (value == null) return null;
+        if (value instanceof Long) return (Long) value;
+        if (value instanceof Number) return ((Number) value).longValue();
+        if (value instanceof String) return Long.parseLong((String) value);
+        return null;
+    }
+    
+    public Double getDecimalValue() {
+        if (value == null) return null;
+        if (value instanceof Double) return (Double) value;
+        if (value instanceof Number) return ((Number) value).doubleValue();
+        if (value instanceof String) return Double.parseDouble((String) value);
+        return null;
+    }
+    
+    public Boolean getBooleanValue() {
+        if (value == null) return null;
+        if (value instanceof Boolean) return (Boolean) value;
+        if (value instanceof String) return Boolean.parseBoolean((String) value);
+        return null;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public List<String> getMultiStringValue() {
+        if (value == null) return null;
+        if (value instanceof List) return (List<String>) value;
+        return List.of(String.valueOf(value));
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AclCapabilities.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AclCapabilities.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "ACL capabilities")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AclCapabilities {
+    
+    @Schema(description = "Supported permissions", example = "basic")
+    @JsonProperty("supportedPermissions")
+    private String supportedPermissions;
+    
+    @Schema(description = "ACL propagation", example = "propagate")
+    @JsonProperty("aclPropagation")
+    private String aclPropagation;
+    
+    @Schema(description = "List of permissions")
+    @JsonProperty("permissions")
+    private List<PermissionDefinition> permissions;
+    
+    @Schema(description = "Permission mapping")
+    @JsonProperty("permissionMapping")
+    private Map<String, List<String>> permissionMapping;
+    
+    public AclCapabilities() {
+    }
+    
+    public String getSupportedPermissions() {
+        return supportedPermissions;
+    }
+    
+    public void setSupportedPermissions(String supportedPermissions) {
+        this.supportedPermissions = supportedPermissions;
+    }
+    
+    public String getAclPropagation() {
+        return aclPropagation;
+    }
+    
+    public void setAclPropagation(String aclPropagation) {
+        this.aclPropagation = aclPropagation;
+    }
+    
+    public List<PermissionDefinition> getPermissions() {
+        return permissions;
+    }
+    
+    public void setPermissions(List<PermissionDefinition> permissions) {
+        this.permissions = permissions;
+    }
+    
+    public Map<String, List<String>> getPermissionMapping() {
+        return permissionMapping;
+    }
+    
+    public void setPermissionMapping(Map<String, List<String>> permissionMapping) {
+        this.permissionMapping = permissionMapping;
+    }
+    
+    @Schema(description = "Permission definition")
+    public static class PermissionDefinition {
+        
+        @Schema(description = "Permission ID", example = "cmis:read")
+        @JsonProperty("permission")
+        private String permission;
+        
+        @Schema(description = "Permission description", example = "Read permission")
+        @JsonProperty("description")
+        private String description;
+        
+        public PermissionDefinition() {
+        }
+        
+        public PermissionDefinition(String permission, String description) {
+            this.permission = permission;
+            this.description = description;
+        }
+        
+        public String getPermission() {
+            return permission;
+        }
+        
+        public void setPermission(String permission) {
+            this.permission = permission;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+        
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/LinkInfo.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/LinkInfo.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "HATEOAS link information")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LinkInfo {
+    
+    @Schema(description = "Link URL", example = "/api/v1/repositories/bedroom/objects/OBJECT_ID")
+    @JsonProperty("href")
+    private String href;
+    
+    @Schema(description = "HTTP method for the link", example = "GET")
+    @JsonProperty("method")
+    private String method;
+    
+    @Schema(description = "Link title/description", example = "Get object details")
+    @JsonProperty("title")
+    private String title;
+    
+    @Schema(description = "Media type of the linked resource", example = "application/json")
+    @JsonProperty("type")
+    private String type;
+    
+    public LinkInfo() {
+    }
+    
+    public LinkInfo(String href) {
+        this.href = href;
+    }
+    
+    public LinkInfo(String href, String method) {
+        this.href = href;
+        this.method = method;
+    }
+    
+    public static LinkInfo of(String href) {
+        return new LinkInfo(href);
+    }
+    
+    public static LinkInfo get(String href) {
+        return new LinkInfo(href, "GET");
+    }
+    
+    public static LinkInfo post(String href) {
+        return new LinkInfo(href, "POST");
+    }
+    
+    public static LinkInfo put(String href) {
+        return new LinkInfo(href, "PUT");
+    }
+    
+    public static LinkInfo delete(String href) {
+        return new LinkInfo(href, "DELETE");
+    }
+    
+    public String getHref() {
+        return href;
+    }
+    
+    public void setHref(String href) {
+        this.href = href;
+    }
+    
+    public String getMethod() {
+        return method;
+    }
+    
+    public void setMethod(String method) {
+        this.method = method;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public LinkInfo withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+    
+    public LinkInfo withType(String type) {
+        this.type = type;
+        return this;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryCapabilities.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryCapabilities.java
@@ -1,0 +1,193 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Repository capabilities")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RepositoryCapabilities {
+    
+    @Schema(description = "ACL capability", example = "manage")
+    @JsonProperty("capabilityAcl")
+    private String capabilityAcl;
+    
+    @Schema(description = "All versions searchable capability")
+    @JsonProperty("capabilityAllVersionsSearchable")
+    private Boolean capabilityAllVersionsSearchable;
+    
+    @Schema(description = "Changes capability", example = "objectidsonly")
+    @JsonProperty("capabilityChanges")
+    private String capabilityChanges;
+    
+    @Schema(description = "Content stream updates capability", example = "anytime")
+    @JsonProperty("capabilityContentStreamUpdatability")
+    private String capabilityContentStreamUpdatability;
+    
+    @Schema(description = "Get descendants capability")
+    @JsonProperty("capabilityGetDescendants")
+    private Boolean capabilityGetDescendants;
+    
+    @Schema(description = "Get folder tree capability")
+    @JsonProperty("capabilityGetFolderTree")
+    private Boolean capabilityGetFolderTree;
+    
+    @Schema(description = "Order by capability", example = "common")
+    @JsonProperty("capabilityOrderBy")
+    private String capabilityOrderBy;
+    
+    @Schema(description = "Multifiling capability")
+    @JsonProperty("capabilityMultifiling")
+    private Boolean capabilityMultifiling;
+    
+    @Schema(description = "PWC searchable capability")
+    @JsonProperty("capabilityPwcSearchable")
+    private Boolean capabilityPwcSearchable;
+    
+    @Schema(description = "PWC updatable capability")
+    @JsonProperty("capabilityPwcUpdatable")
+    private Boolean capabilityPwcUpdatable;
+    
+    @Schema(description = "Query capability", example = "bothcombined")
+    @JsonProperty("capabilityQuery")
+    private String capabilityQuery;
+    
+    @Schema(description = "Renditions capability", example = "read")
+    @JsonProperty("capabilityRenditions")
+    private String capabilityRenditions;
+    
+    @Schema(description = "Unfiling capability")
+    @JsonProperty("capabilityUnfiling")
+    private Boolean capabilityUnfiling;
+    
+    @Schema(description = "Version specific filing capability")
+    @JsonProperty("capabilityVersionSpecificFiling")
+    private Boolean capabilityVersionSpecificFiling;
+    
+    @Schema(description = "Join capability", example = "none")
+    @JsonProperty("capabilityJoin")
+    private String capabilityJoin;
+    
+    public RepositoryCapabilities() {
+    }
+    
+    public String getCapabilityAcl() {
+        return capabilityAcl;
+    }
+    
+    public void setCapabilityAcl(String capabilityAcl) {
+        this.capabilityAcl = capabilityAcl;
+    }
+    
+    public Boolean getCapabilityAllVersionsSearchable() {
+        return capabilityAllVersionsSearchable;
+    }
+    
+    public void setCapabilityAllVersionsSearchable(Boolean capabilityAllVersionsSearchable) {
+        this.capabilityAllVersionsSearchable = capabilityAllVersionsSearchable;
+    }
+    
+    public String getCapabilityChanges() {
+        return capabilityChanges;
+    }
+    
+    public void setCapabilityChanges(String capabilityChanges) {
+        this.capabilityChanges = capabilityChanges;
+    }
+    
+    public String getCapabilityContentStreamUpdatability() {
+        return capabilityContentStreamUpdatability;
+    }
+    
+    public void setCapabilityContentStreamUpdatability(String capabilityContentStreamUpdatability) {
+        this.capabilityContentStreamUpdatability = capabilityContentStreamUpdatability;
+    }
+    
+    public Boolean getCapabilityGetDescendants() {
+        return capabilityGetDescendants;
+    }
+    
+    public void setCapabilityGetDescendants(Boolean capabilityGetDescendants) {
+        this.capabilityGetDescendants = capabilityGetDescendants;
+    }
+    
+    public Boolean getCapabilityGetFolderTree() {
+        return capabilityGetFolderTree;
+    }
+    
+    public void setCapabilityGetFolderTree(Boolean capabilityGetFolderTree) {
+        this.capabilityGetFolderTree = capabilityGetFolderTree;
+    }
+    
+    public String getCapabilityOrderBy() {
+        return capabilityOrderBy;
+    }
+    
+    public void setCapabilityOrderBy(String capabilityOrderBy) {
+        this.capabilityOrderBy = capabilityOrderBy;
+    }
+    
+    public Boolean getCapabilityMultifiling() {
+        return capabilityMultifiling;
+    }
+    
+    public void setCapabilityMultifiling(Boolean capabilityMultifiling) {
+        this.capabilityMultifiling = capabilityMultifiling;
+    }
+    
+    public Boolean getCapabilityPwcSearchable() {
+        return capabilityPwcSearchable;
+    }
+    
+    public void setCapabilityPwcSearchable(Boolean capabilityPwcSearchable) {
+        this.capabilityPwcSearchable = capabilityPwcSearchable;
+    }
+    
+    public Boolean getCapabilityPwcUpdatable() {
+        return capabilityPwcUpdatable;
+    }
+    
+    public void setCapabilityPwcUpdatable(Boolean capabilityPwcUpdatable) {
+        this.capabilityPwcUpdatable = capabilityPwcUpdatable;
+    }
+    
+    public String getCapabilityQuery() {
+        return capabilityQuery;
+    }
+    
+    public void setCapabilityQuery(String capabilityQuery) {
+        this.capabilityQuery = capabilityQuery;
+    }
+    
+    public String getCapabilityRenditions() {
+        return capabilityRenditions;
+    }
+    
+    public void setCapabilityRenditions(String capabilityRenditions) {
+        this.capabilityRenditions = capabilityRenditions;
+    }
+    
+    public Boolean getCapabilityUnfiling() {
+        return capabilityUnfiling;
+    }
+    
+    public void setCapabilityUnfiling(Boolean capabilityUnfiling) {
+        this.capabilityUnfiling = capabilityUnfiling;
+    }
+    
+    public Boolean getCapabilityVersionSpecificFiling() {
+        return capabilityVersionSpecificFiling;
+    }
+    
+    public void setCapabilityVersionSpecificFiling(Boolean capabilityVersionSpecificFiling) {
+        this.capabilityVersionSpecificFiling = capabilityVersionSpecificFiling;
+    }
+    
+    public String getCapabilityJoin() {
+        return capabilityJoin;
+    }
+    
+    public void setCapabilityJoin(String capabilityJoin) {
+        this.capabilityJoin = capabilityJoin;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryInfoResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryInfoResponse.java
@@ -1,0 +1,207 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+@Schema(description = "Repository information response")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RepositoryInfoResponse {
+    
+    @Schema(description = "Repository ID", example = "bedroom")
+    @JsonProperty("repositoryId")
+    private String repositoryId;
+    
+    @Schema(description = "Repository name", example = "Bedroom Repository")
+    @JsonProperty("repositoryName")
+    private String repositoryName;
+    
+    @Schema(description = "Repository description", example = "Main content repository")
+    @JsonProperty("repositoryDescription")
+    private String repositoryDescription;
+    
+    @Schema(description = "Vendor name", example = "aegif")
+    @JsonProperty("vendorName")
+    private String vendorName;
+    
+    @Schema(description = "Product name", example = "NemakiWare")
+    @JsonProperty("productName")
+    private String productName;
+    
+    @Schema(description = "Product version", example = "3.0.0")
+    @JsonProperty("productVersion")
+    private String productVersion;
+    
+    @Schema(description = "Root folder ID")
+    @JsonProperty("rootFolderId")
+    private String rootFolderId;
+    
+    @Schema(description = "CMIS version supported", example = "1.1")
+    @JsonProperty("cmisVersionSupported")
+    private String cmisVersionSupported;
+    
+    @Schema(description = "Principal ID for anonymous user")
+    @JsonProperty("principalIdAnonymous")
+    private String principalIdAnonymous;
+    
+    @Schema(description = "Principal ID for anyone")
+    @JsonProperty("principalIdAnyone")
+    private String principalIdAnyone;
+    
+    @Schema(description = "Thin client URI")
+    @JsonProperty("thinClientUri")
+    private String thinClientUri;
+    
+    @Schema(description = "Whether changes on type are supported")
+    @JsonProperty("changesOnType")
+    private Boolean changesOnType;
+    
+    @Schema(description = "Latest change log token")
+    @JsonProperty("latestChangeLogToken")
+    private String latestChangeLogToken;
+    
+    @Schema(description = "Repository capabilities")
+    @JsonProperty("capabilities")
+    private RepositoryCapabilities capabilities;
+    
+    @Schema(description = "ACL capabilities")
+    @JsonProperty("aclCapabilities")
+    private AclCapabilities aclCapabilities;
+    
+    @Schema(description = "HATEOAS links")
+    @JsonProperty("_links")
+    private Map<String, LinkInfo> links;
+    
+    public RepositoryInfoResponse() {
+    }
+    
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+    
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+    
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+    
+    public void setRepositoryName(String repositoryName) {
+        this.repositoryName = repositoryName;
+    }
+    
+    public String getRepositoryDescription() {
+        return repositoryDescription;
+    }
+    
+    public void setRepositoryDescription(String repositoryDescription) {
+        this.repositoryDescription = repositoryDescription;
+    }
+    
+    public String getVendorName() {
+        return vendorName;
+    }
+    
+    public void setVendorName(String vendorName) {
+        this.vendorName = vendorName;
+    }
+    
+    public String getProductName() {
+        return productName;
+    }
+    
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+    
+    public String getProductVersion() {
+        return productVersion;
+    }
+    
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
+    
+    public String getRootFolderId() {
+        return rootFolderId;
+    }
+    
+    public void setRootFolderId(String rootFolderId) {
+        this.rootFolderId = rootFolderId;
+    }
+    
+    public String getCmisVersionSupported() {
+        return cmisVersionSupported;
+    }
+    
+    public void setCmisVersionSupported(String cmisVersionSupported) {
+        this.cmisVersionSupported = cmisVersionSupported;
+    }
+    
+    public String getPrincipalIdAnonymous() {
+        return principalIdAnonymous;
+    }
+    
+    public void setPrincipalIdAnonymous(String principalIdAnonymous) {
+        this.principalIdAnonymous = principalIdAnonymous;
+    }
+    
+    public String getPrincipalIdAnyone() {
+        return principalIdAnyone;
+    }
+    
+    public void setPrincipalIdAnyone(String principalIdAnyone) {
+        this.principalIdAnyone = principalIdAnyone;
+    }
+    
+    public String getThinClientUri() {
+        return thinClientUri;
+    }
+    
+    public void setThinClientUri(String thinClientUri) {
+        this.thinClientUri = thinClientUri;
+    }
+    
+    public Boolean getChangesOnType() {
+        return changesOnType;
+    }
+    
+    public void setChangesOnType(Boolean changesOnType) {
+        this.changesOnType = changesOnType;
+    }
+    
+    public String getLatestChangeLogToken() {
+        return latestChangeLogToken;
+    }
+    
+    public void setLatestChangeLogToken(String latestChangeLogToken) {
+        this.latestChangeLogToken = latestChangeLogToken;
+    }
+    
+    public RepositoryCapabilities getCapabilities() {
+        return capabilities;
+    }
+    
+    public void setCapabilities(RepositoryCapabilities capabilities) {
+        this.capabilities = capabilities;
+    }
+    
+    public AclCapabilities getAclCapabilities() {
+        return aclCapabilities;
+    }
+    
+    public void setAclCapabilities(AclCapabilities aclCapabilities) {
+        this.aclCapabilities = aclCapabilities;
+    }
+    
+    public Map<String, LinkInfo> getLinks() {
+        return links;
+    }
+    
+    public void setLinks(Map<String, LinkInfo> links) {
+        this.links = links;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/RepositoryResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/RepositoryResource.java
@@ -1,0 +1,382 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.RepositoryInfoResponse;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.data.PermissionMapping;
+import org.apache.chemistry.opencmis.commons.data.RepositoryInfo;
+import org.apache.chemistry.opencmis.commons.definitions.PermissionDefinition;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories")
+@Tag(name = "repositories", description = "Repository management operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class RepositoryResource {
+    
+    private static final Logger logger = Logger.getLogger(RepositoryResource.class.getName());
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @GET
+    @Operation(
+            summary = "List all repositories",
+            description = "Returns a list of all available repositories with their basic information"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of repositories",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = RepositoryInfoResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response listRepositories() {
+        logger.info("API v1: Listing all repositories");
+        
+        try {
+            List<RepositoryInfo> repositoryInfos = repositoryService.getRepositoryInfos();
+            
+            List<RepositoryInfoResponse> responses = new ArrayList<>();
+            for (RepositoryInfo repoInfo : repositoryInfos) {
+                responses.add(mapToResponse(repoInfo, false));
+            }
+            
+            return Response.ok(responses).build();
+        } catch (Exception e) {
+            logger.severe("Error listing repositories: " + e.getMessage());
+            throw ApiException.internalError("Failed to list repositories: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{repositoryId}")
+    @Operation(
+            summary = "Get repository information",
+            description = "Returns detailed information about a specific repository including capabilities"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Repository information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RepositoryInfoResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Repository not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getRepository(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId) {
+        
+        logger.info("API v1: Getting repository info for: " + repositoryId);
+        
+        try {
+            if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.cmis.factory.info.RepositoryInfo repoInfo = 
+                    repositoryService.getRepositoryInfo(repositoryId);
+            
+            if (repoInfo == null) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            RepositoryInfoResponse response = mapToResponse(repoInfo, true);
+            return Response.ok(response).build();
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting repository " + repositoryId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get repository: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{repositoryId}/capabilities")
+    @Operation(
+            summary = "Get repository capabilities",
+            description = "Returns the capabilities of a specific repository"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Repository capabilities",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Repository not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getRepositoryCapabilities(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId) {
+        
+        logger.info("API v1: Getting capabilities for repository: " + repositoryId);
+        
+        try {
+            if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.cmis.factory.info.RepositoryInfo repoInfo = 
+                    repositoryService.getRepositoryInfo(repositoryId);
+            
+            if (repoInfo == null) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities capabilities = 
+                    mapCapabilities(repoInfo.getCapabilities());
+            
+            return Response.ok(capabilities).build();
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting capabilities for " + repositoryId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get repository capabilities: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{repositoryId}/rootFolder")
+    @Operation(
+            summary = "Get root folder information",
+            description = "Returns information about the root folder of the repository"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Root folder ID and link",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Repository not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getRootFolder(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId) {
+        
+        logger.info("API v1: Getting root folder for repository: " + repositoryId);
+        
+        try {
+            if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.cmis.factory.info.RepositoryInfo repoInfo = 
+                    repositoryService.getRepositoryInfo(repositoryId);
+            
+            if (repoInfo == null) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            String rootFolderId = repoInfo.getRootFolderId();
+            String baseUri = uriInfo.getBaseUri().toString();
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("rootFolderId", rootFolderId);
+            response.put("_links", Map.of(
+                    "self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/rootFolder"),
+                    "folder", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + rootFolderId),
+                    "children", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + rootFolderId + "/children")
+            ));
+            
+            return Response.ok(response).build();
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting root folder for " + repositoryId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get root folder: " + e.getMessage(), e);
+        }
+    }
+    
+    private RepositoryInfoResponse mapToResponse(RepositoryInfo repoInfo, boolean includeDetails) {
+        RepositoryInfoResponse response = new RepositoryInfoResponse();
+        
+        response.setRepositoryId(repoInfo.getId());
+        response.setRepositoryName(repoInfo.getName());
+        response.setRepositoryDescription(repoInfo.getDescription());
+        response.setVendorName(repoInfo.getVendorName());
+        response.setProductName(repoInfo.getProductName());
+        response.setProductVersion(repoInfo.getProductVersion());
+        response.setRootFolderId(repoInfo.getRootFolderId());
+        response.setCmisVersionSupported(repoInfo.getCmisVersionSupported());
+        response.setPrincipalIdAnonymous(repoInfo.getPrincipalIdAnonymous());
+        response.setPrincipalIdAnyone(repoInfo.getPrincipalIdAnyone());
+        response.setThinClientUri(repoInfo.getThinClientUri());
+        response.setLatestChangeLogToken(repoInfo.getLatestChangeLogToken());
+        
+        if (includeDetails) {
+            if (repoInfo.getCapabilities() != null) {
+                response.setCapabilities(mapCapabilities(repoInfo.getCapabilities()));
+            }
+            if (repoInfo.getAclCapabilities() != null) {
+                response.setAclCapabilities(mapAclCapabilities(repoInfo.getAclCapabilities()));
+            }
+        }
+        
+        // Add HATEOAS links
+        String baseUri = uriInfo.getBaseUri().toString();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId()));
+        links.put("rootFolder", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/rootFolder"));
+        links.put("types", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/types"));
+        links.put("objects", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/objects"));
+        links.put("query", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/query"));
+        links.put("users", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/users"));
+        links.put("groups", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/groups"));
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities mapCapabilities(
+            org.apache.chemistry.opencmis.commons.data.RepositoryCapabilities caps) {
+        if (caps == null) return null;
+        
+        jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities response = 
+                new jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities();
+        
+        if (caps.getAclCapability() != null) {
+            response.setCapabilityAcl(caps.getAclCapability().value());
+        }
+        response.setCapabilityAllVersionsSearchable(caps.isAllVersionsSearchableSupported());
+        if (caps.getChangesCapability() != null) {
+            response.setCapabilityChanges(caps.getChangesCapability().value());
+        }
+        if (caps.getContentStreamUpdatesCapability() != null) {
+            response.setCapabilityContentStreamUpdatability(caps.getContentStreamUpdatesCapability().value());
+        }
+        response.setCapabilityGetDescendants(caps.isGetDescendantsSupported());
+        response.setCapabilityGetFolderTree(caps.isGetFolderTreeSupported());
+        if (caps.getOrderByCapability() != null) {
+            response.setCapabilityOrderBy(caps.getOrderByCapability().value());
+        }
+        response.setCapabilityMultifiling(caps.isMultifilingSupported());
+        response.setCapabilityPwcSearchable(caps.isPwcSearchableSupported());
+        response.setCapabilityPwcUpdatable(caps.isPwcUpdatableSupported());
+        if (caps.getQueryCapability() != null) {
+            response.setCapabilityQuery(caps.getQueryCapability().value());
+        }
+        if (caps.getRenditionsCapability() != null) {
+            response.setCapabilityRenditions(caps.getRenditionsCapability().value());
+        }
+        response.setCapabilityUnfiling(caps.isUnfilingSupported());
+        response.setCapabilityVersionSpecificFiling(caps.isVersionSpecificFilingSupported());
+        if (caps.getJoinCapability() != null) {
+            response.setCapabilityJoin(caps.getJoinCapability().value());
+        }
+        
+        return response;
+    }
+    
+    private jp.aegif.nemaki.api.v1.model.response.AclCapabilities mapAclCapabilities(
+            org.apache.chemistry.opencmis.commons.data.AclCapabilities aclCaps) {
+        if (aclCaps == null) return null;
+        
+        jp.aegif.nemaki.api.v1.model.response.AclCapabilities response = 
+                new jp.aegif.nemaki.api.v1.model.response.AclCapabilities();
+        
+        if (aclCaps.getSupportedPermissions() != null) {
+            response.setSupportedPermissions(aclCaps.getSupportedPermissions().value());
+        }
+        if (aclCaps.getAclPropagation() != null) {
+            response.setAclPropagation(aclCaps.getAclPropagation().value());
+        }
+        
+        // Map permissions
+        if (aclCaps.getPermissions() != null) {
+            List<jp.aegif.nemaki.api.v1.model.response.AclCapabilities.PermissionDefinition> permissions = new ArrayList<>();
+            for (PermissionDefinition perm : aclCaps.getPermissions()) {
+                permissions.add(new jp.aegif.nemaki.api.v1.model.response.AclCapabilities.PermissionDefinition(
+                        perm.getId(), perm.getDescription()));
+            }
+            response.setPermissions(permissions);
+        }
+        
+        // Map permission mapping
+        if (aclCaps.getPermissionMapping() != null) {
+            Map<String, List<String>> mapping = new HashMap<>();
+            for (PermissionMapping pm : aclCaps.getPermissionMapping().values()) {
+                mapping.put(pm.getKey(), pm.getPermissions());
+            }
+            response.setPermissionMapping(mapping);
+        }
+        
+        return response;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/rest/AuthenticationFilter.java
+++ b/core/src/main/java/jp/aegif/nemaki/rest/AuthenticationFilter.java
@@ -37,8 +37,6 @@ import org.apache.chemistry.opencmis.commons.server.CallContext;
 import org.apache.chemistry.opencmis.server.impl.CallContextImpl;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -72,22 +70,16 @@ public class AuthenticationFilter implements Filter {
 		HttpServletRequest hreq = (HttpServletRequest) req;
 		HttpServletResponse hres = (HttpServletResponse) res;
 
+		// CORS is handled by SimpleCorsFilter in web.xml - do not add CORS headers here
+		// to avoid duplicate header application
+		
 		// Handle CORS preflight requests (OPTIONS) - bypass authentication
+		// SimpleCorsFilter handles the actual CORS headers, we just need to bypass auth
 		if ("OPTIONS".equalsIgnoreCase(hreq.getMethod())) {
-			log.info("=== CORS: Handling OPTIONS preflight request ===");
-			// Set CORS headers
-			hres.setHeader("Access-Control-Allow-Origin", "*");
-			hres.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-			hres.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, AUTH_TOKEN, nemaki_auth_token");
-			hres.setHeader("Access-Control-Max-Age", "3600");
-			hres.setStatus(HttpServletResponse.SC_OK);
+			log.info("=== CORS: Bypassing authentication for OPTIONS preflight request ===");
+			chain.doFilter(req, res);
 			return;
 		}
-
-		// Add CORS headers to all responses
-		hres.setHeader("Access-Control-Allow-Origin", "*");
-		hres.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-		hres.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, AUTH_TOKEN, nemaki_auth_token");
 
 		// Check if this is a path that should bypass authentication
 		String requestURI = hreq.getRequestURI();

--- a/core/src/main/webapp/WEB-INF/web.xml
+++ b/core/src/main/webapp/WEB-INF/web.xml
@@ -132,6 +132,10 @@
 		<filter-name>corsFilter</filter-name>
 		<url-pattern>/rest/*</url-pattern>
 	</filter-mapping>
+	<filter-mapping>
+		<filter-name>corsFilter</filter-name>
+		<url-pattern>/api/v1/*</url-pattern>
+	</filter-mapping>
 	
 	<!-- DeleteType filter mapping - TEMPORARILY DISABLED to allow query action support -->
 	<!-- CRITICAL FIX: This filter mapping prevents cmisaction=query from working in TCK tests -->
@@ -195,6 +199,11 @@
 	<filter-mapping>
 		<filter-name>restAuthenticationFilter</filter-name>
 		<url-pattern>/api/*</url-pattern>
+	</filter-mapping>
+	<!-- Apply authentication to /api/v1/* endpoints (OpenAPI REST API v1) -->
+	<filter-mapping>
+		<filter-name>restAuthenticationFilter</filter-name>
+		<url-pattern>/api/v1/*</url-pattern>
 	</filter-mapping>
 
 
@@ -270,6 +279,27 @@
  <servlet-mapping>
   <servlet-name>jersey-app</servlet-name>
   <url-pattern>/rest/*</url-pattern>
+ </servlet-mapping>
+
+ <!-- Jersey application for OpenAPI v1 REST endpoints -->
+ <servlet>
+  <servlet-name>jersey-api-v1</servlet-name>
+  <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+  <init-param>
+        <param-name>jakarta.ws.rs.Application</param-name>
+        <param-value>jp.aegif.nemaki.api.v1.ApiV1Application</param-value>
+    </init-param>
+    <!-- Enable Jersey-Spring integration -->
+    <init-param>
+        <param-name>jersey.config.server.provider.classnames</param-name>
+        <param-value>org.glassfish.jersey.server.spring.SpringLifecycleListener</param-value>
+    </init-param>
+    <load-on-startup>11</load-on-startup>
+ </servlet>
+
+ <servlet-mapping>
+  <servlet-name>jersey-api-v1</servlet-name>
+  <url-pattern>/api/v1/*</url-pattern>
  </servlet-mapping>
 
  <!-- Simple servlet for /rest/all/repositories endpoint -->

--- a/docs/design/REST-API-ODATA-DESIGN.md
+++ b/docs/design/REST-API-ODATA-DESIGN.md
@@ -1,0 +1,1300 @@
+# NemakiWare OpenAPI REST API & OData 設計書
+
+## 1. 概要
+
+本設計書は、NemakiWare 3.0.0 の次期リリースにおける OpenAPI 準拠 REST API の拡充と OData 4.0 対応の詳細設計を記述します。
+
+### 1.1 背景
+
+現在の NemakiWare は以下の API を提供しています：
+
+1. **CMIS 1.1 バインディング** - AtomPub バインディング (`/atom/`) と Browser バインディング (`/browser/`)
+2. **独自 REST API** (`/rest/`) - CMIS にない操作（ユーザー管理、グループ管理、タイプ管理など）
+
+本設計では、CMIS の全機能を OpenAPI 準拠の REST API として公開し、さらに OData 4.0 プロトコルによるデータアクセスを可能にします。
+
+### 1.2 設計目標
+
+1. **OpenAPI 3.0 準拠**: 完全なドキュメント化された REST API の提供
+2. **CMIS 全機能の REST 化**: CMIS バインディングでのみ利用可能だった操作を REST API として公開
+3. **OData 4.0 対応**: 標準的なクエリ機能によるコンテンツ検索・ナビゲーション
+4. **後方互換性**: 既存の REST エンドポイントの維持
+5. **セキュリティ**: 適切な認証・認可の実装
+
+### 1.3 対象バージョン
+
+- ベースブランチ: `release/3.0.0-RC1-QA`
+- ターゲットリリース: 3.1.0 または 4.0.0
+
+---
+
+## 2. 現状分析
+
+### 2.1 既存 REST API エンドポイント
+
+現在の `/rest/` パス配下で提供されている API：
+
+| カテゴリ | パス | 機能 |
+|---------|------|------|
+| ユーザー管理 | `/rest/repo/{repositoryId}/user/` | CRUD、検索、パスワード変更 |
+| グループ管理 | `/rest/repo/{repositoryId}/group/` | CRUD、メンバー管理 |
+| タイプ管理 | `/rest/repo/{repositoryId}/type/` | CRUD、XML/JSON インポート |
+| アーカイブ | `/rest/repo/{repositoryId}/archive/` | 一覧、復元、完全削除 |
+| ACL | `/rest/repo/{repositoryId}/node/{objectId}/acl` | 取得、設定 |
+| 認証 | `/rest/repo/{repositoryId}/authtoken/` | トークン発行、SAML/OIDC 連携 |
+| キャッシュ | `/rest/repo/{repositoryId}/cache/` | キャッシュ無効化 |
+| 検索エンジン | `/rest/repo/{repositoryId}/search-engine/` | Solr 管理、再インデックス |
+| レンディション | `/rest/repo/{repositoryId}/renditions/` | PDF 変換、取得 |
+| リポジトリ | `/rest/all/repositories` | リポジトリ一覧 |
+
+### 2.2 CMIS サービス（REST 未公開）
+
+現在 CMIS バインディングでのみ利用可能な操作：
+
+#### ObjectService
+- `create`, `createDocument`, `createFolder`, `createRelationship`, `createPolicy`, `createItem`
+- `getObject`, `getObjectByPath`
+- `updateProperties`, `bulkUpdateProperties`
+- `deleteObject`, `deleteTree`
+- `moveObject`
+- `setContentStream`, `deleteContentStream`, `appendContentStream`
+- `getContentStream`
+- `getRenditions`
+- `getAllowableActions`
+
+#### NavigationService
+- `getChildren`
+- `getDescendants`
+- `getFolderParent`
+- `getObjectParents`
+- `getCheckedOutDocs`
+
+#### RepositoryService
+- `getRepositoryInfo`, `getRepositoryInfos`
+- `getTypeChildren`, `getTypeDescendants`
+- `getTypeDefinition`
+- `createType`, `updateType`, `deleteType`
+
+#### AclService
+- `getAcl`
+- `applyAcl`
+
+#### VersioningService
+- `checkOut`, `cancelCheckOut`, `checkIn`
+- `getAllVersions`
+- `getObjectOfLatestVersion`
+
+#### DiscoveryService
+- `query`
+- `getContentChanges`
+
+#### RelationshipService
+- `getObjectRelationships`
+
+#### PolicyService
+- `applyPolicy`, `removePolicy`
+- `getAppliedPolicies`
+
+---
+
+## 3. OpenAPI REST API 設計
+
+### 3.1 URL 構造
+
+```
+/api/v1/                           # 新規 OpenAPI 準拠 REST API
+/rest/                             # 既存 REST API（後方互換性維持）
+/odata/{repositoryId}/             # OData エンドポイント
+/atom/{repositoryId}/              # CMIS AtomPub バインディング（既存）
+/browser/{repositoryId}/           # CMIS Browser バインディング（既存）
+```
+
+### 3.2 リソース設計方針
+
+#### 3.2.1 Object/Document/Folder の境界設計
+
+CMIS では全てのコンテンツが「オブジェクト」として扱われますが、REST API では以下の方針で設計します：
+
+**設計原則:**
+- `/objects/{id}` を**正規（canonical）エンドポイント**として、任意のオブジェクトにアクセス可能
+- `/documents` と `/folders` は**便宜的なエンドポイント**として、以下の用途に限定：
+  - 作成操作（POST）: タイプ固有のバリデーションと簡略化されたリクエスト
+  - タイプ固有操作: チェックアウト/チェックインは `/documents` のみ
+  - 検索/一覧: タイプでフィルタされた結果の取得
+
+**使い分けガイドライン:**
+
+| 操作 | 推奨エンドポイント | 理由 |
+|------|-------------------|------|
+| 任意オブジェクト取得 | `/objects/{id}` | タイプに依存しない汎用アクセス |
+| ドキュメント作成 | `/documents` | バージョニング状態の指定が必要 |
+| フォルダ作成 | `/folders` | 親フォルダの指定が必須 |
+| チェックアウト/チェックイン | `/documents/{id}/checkout` | ドキュメント固有操作 |
+| プロパティ更新 | `/objects/{id}` | タイプに依存しない |
+| コンテンツ取得/更新 | `/objects/{id}/content` | タイプに依存しない |
+
+### 3.3 プロパティの型表現（動的プロパティ対応）
+
+#### 3.3.1 課題
+
+CMIS の型定義は動的であり、カスタムタイプごとにプロパティが異なります。OpenAPI のスキーマは静的であるため、`additionalProperties: true` を使用すると型情報が失われ、SDK 生成の価値が低下します。
+
+#### 3.3.2 解決策：2層構造プロパティ表現
+
+プロパティを `value` と `type` を含む構造化オブジェクトとして表現します：
+
+```json
+{
+  "objectId": "OBJECT_ID",
+  "objectTypeId": "custom:invoice",
+  "baseTypeId": "cmis:document",
+  "properties": {
+    "cmis:name": {
+      "value": "invoice-2026-001.pdf",
+      "type": "string",
+      "displayName": "Name"
+    },
+    "cmis:creationDate": {
+      "value": "2026-01-19T10:00:00Z",
+      "type": "datetime",
+      "displayName": "Creation Date"
+    },
+    "cmis:contentStreamLength": {
+      "value": 12345,
+      "type": "integer",
+      "displayName": "Content Stream Length"
+    },
+    "custom:invoiceNumber": {
+      "value": "INV-2026-001",
+      "type": "string",
+      "displayName": "Invoice Number"
+    },
+    "custom:amount": {
+      "value": 150000.00,
+      "type": "decimal",
+      "displayName": "Amount"
+    },
+    "custom:tags": {
+      "value": ["finance", "2026", "Q1"],
+      "type": "string",
+      "cardinality": "multi",
+      "displayName": "Tags"
+    }
+  }
+}
+```
+
+#### 3.3.3 プロパティ型マッピング
+
+| CMIS PropertyType | JSON 表現 | type 値 |
+|-------------------|-----------|---------|
+| string | string | "string" |
+| boolean | boolean | "boolean" |
+| integer | number (integer) | "integer" |
+| decimal | number | "decimal" |
+| datetime | string (ISO 8601) | "datetime" |
+| uri | string | "uri" |
+| id | string | "id" |
+| html | string | "html" |
+
+#### 3.3.4 動的スキーマ生成エンドポイント
+
+タイプ定義から OpenAPI スキーマを動的に生成するエンドポイントを提供：
+
+```
+GET /api/v1/repositories/{repositoryId}/types/{typeId}/schema
+```
+
+**レスポンス例:**
+```json
+{
+  "typeId": "custom:invoice",
+  "openApiSchema": {
+    "type": "object",
+    "properties": {
+      "objectId": {"type": "string"},
+      "objectTypeId": {"type": "string", "const": "custom:invoice"},
+      "properties": {
+        "type": "object",
+        "properties": {
+          "custom:invoiceNumber": {
+            "type": "object",
+            "properties": {
+              "value": {"type": "string"},
+              "type": {"type": "string", "const": "string"}
+            },
+            "required": ["value"]
+          },
+          "custom:amount": {
+            "type": "object",
+            "properties": {
+              "value": {"type": "number"},
+              "type": {"type": "string", "const": "decimal"}
+            },
+            "required": ["value"]
+          }
+        },
+        "required": ["custom:invoiceNumber", "custom:amount"]
+      }
+    }
+  }
+}
+```
+
+**SDK 生成ワークフロー:**
+1. `/types` エンドポイントでタイプ一覧を取得
+2. 各タイプの `/types/{typeId}/schema` でスキーマを取得
+3. 取得したスキーマを使用してタイプ固有の DTO を生成
+
+### 3.4 リソース設計
+
+#### 3.4.1 リポジトリ (`/api/v1/repositories`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/` | リポジトリ一覧取得 | getRepositoryInfos |
+| GET | `/{repositoryId}` | リポジトリ情報取得 | getRepositoryInfo |
+| GET | `/{repositoryId}/capabilities` | ケイパビリティ取得 | getRepositoryInfo |
+| GET | `/{repositoryId}/rootFolder` | ルートフォルダ取得 | - |
+
+#### 3.4.2 オブジェクト (`/api/v1/repositories/{repositoryId}/objects`)
+
+**正規エンドポイント** - 任意のオブジェクトタイプにアクセス可能
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/{objectId}` | オブジェクト取得 | getObject |
+| GET | `/byPath` | パスでオブジェクト取得 | getObjectByPath |
+| POST | `/` | オブジェクト作成 | create |
+| PUT | `/{objectId}` | プロパティ更新 | updateProperties |
+| PUT | `/bulk` | 一括プロパティ更新 | bulkUpdateProperties |
+| DELETE | `/{objectId}` | オブジェクト削除 | deleteObject |
+| POST | `/{objectId}/move` | オブジェクト移動 | moveObject |
+| GET | `/{objectId}/allowableActions` | 許可アクション取得 | getAllowableActions |
+| GET | `/{objectId}/content` | コンテンツストリーム取得 | getContentStream |
+| PUT | `/{objectId}/content` | コンテンツストリーム設定 | setContentStream |
+| DELETE | `/{objectId}/content` | コンテンツストリーム削除 | deleteContentStream |
+| POST | `/{objectId}/content/append` | コンテンツ追記 | appendContentStream |
+| GET | `/{objectId}/renditions` | レンディション取得 | getRenditions |
+| GET | `/{objectId}/parents` | 親オブジェクト取得 | getObjectParents |
+| GET | `/{objectId}/relationships` | リレーションシップ取得 | getObjectRelationships |
+
+#### 3.4.3 コンテンツストリーム操作
+
+##### PUT /objects/{objectId}/content - コンテンツ設定
+
+**リクエスト形式:**
+
+**方式1: Raw Binary（推奨）**
+```
+PUT /api/v1/repositories/{repoId}/objects/{objectId}/content
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="document.pdf"
+X-Overwrite-Flag: true
+X-Change-Token: {changeToken}
+
+[binary content]
+```
+
+**方式2: Multipart（メタデータ同時更新時）**
+```
+POST /api/v1/repositories/{repoId}/objects/{objectId}/content
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundary
+
+------WebKitFormBoundary
+Content-Disposition: form-data; name="file"; filename="document.pdf"
+Content-Type: application/pdf
+
+[binary content]
+------WebKitFormBoundary
+Content-Disposition: form-data; name="overwriteFlag"
+
+true
+------WebKitFormBoundary--
+```
+
+**レスポンス:**
+```json
+{
+  "objectId": "OBJECT_ID",
+  "changeToken": "NEW_CHANGE_TOKEN",
+  "contentStreamLength": 12345,
+  "contentStreamMimeType": "application/pdf",
+  "contentStreamFileName": "document.pdf"
+}
+```
+
+##### GET /objects/{objectId}/content - コンテンツ取得
+
+**レスポンスヘッダー:**
+```
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="document.pdf"
+Content-Length: 12345
+ETag: "CONTENT_HASH"
+```
+
+#### 3.4.4 フォルダ (`/api/v1/repositories/{repositoryId}/folders`)
+
+**便宜的エンドポイント** - フォルダ固有の操作とナビゲーション
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | フォルダ作成 | createFolder |
+| GET | `/{folderId}` | フォルダ取得 | getObject |
+| GET | `/{folderId}/children` | 子オブジェクト取得 | getChildren |
+| GET | `/{folderId}/descendants` | 子孫オブジェクト取得 | getDescendants |
+| GET | `/{folderId}/tree` | フォルダツリー取得 | getFolderTree |
+| GET | `/{folderId}/parent` | 親フォルダ取得 | getFolderParent |
+| DELETE | `/{folderId}/tree` | ツリー削除 | deleteTree |
+
+#### 3.4.5 ドキュメント (`/api/v1/repositories/{repositoryId}/documents`)
+
+**便宜的エンドポイント** - ドキュメント固有の操作（バージョニング）
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | ドキュメント作成 | createDocument |
+| POST | `/fromSource` | コピー作成 | createDocumentFromSource |
+| GET | `/{documentId}/versions` | 全バージョン取得 | getAllVersions |
+| GET | `/{documentId}/latestVersion` | 最新バージョン取得 | getObjectOfLatestVersion |
+| POST | `/{documentId}/checkout` | チェックアウト | checkOut |
+| POST | `/{documentId}/cancelCheckout` | チェックアウト取消 | cancelCheckOut |
+| POST | `/{documentId}/checkin` | チェックイン | checkIn |
+| GET | `/checkedout` | チェックアウト一覧 | getCheckedOutDocs |
+
+##### バージョニング操作のレスポンス仕様
+
+**POST /documents/{documentId}/checkout レスポンス:**
+
+チェックアウト操作は PWC (Private Working Copy) を作成し、その情報を返します。
+
+```json
+{
+  "pwcId": "PWC_OBJECT_ID",
+  "originalObjectId": "ORIGINAL_OBJECT_ID",
+  "versionSeriesId": "VERSION_SERIES_ID",
+  "versionSeriesCheckedOutId": "PWC_OBJECT_ID",
+  "versionSeriesCheckedOutBy": "admin",
+  "isVersionSeriesCheckedOut": true,
+  "_links": {
+    "pwc": {"href": "/api/v1/repositories/bedroom/objects/PWC_OBJECT_ID"},
+    "original": {"href": "/api/v1/repositories/bedroom/objects/ORIGINAL_OBJECT_ID"},
+    "checkin": {"href": "/api/v1/repositories/bedroom/documents/PWC_OBJECT_ID/checkin"}
+  }
+}
+```
+
+**POST /documents/{documentId}/checkin リクエスト:**
+
+```json
+{
+  "major": true,
+  "checkinComment": "Updated version with corrections",
+  "properties": {
+    "cmis:description": {"value": "Updated description"}
+  }
+}
+```
+
+**POST /documents/{documentId}/checkin レスポンス:**
+
+チェックイン操作は**新しいバージョンのオブジェクト情報**を返します。PWC ID は無効になります。
+
+```json
+{
+  "objectId": "NEW_VERSION_OBJECT_ID",
+  "versionSeriesId": "VERSION_SERIES_ID",
+  "versionLabel": "2.0",
+  "isMajorVersion": true,
+  "isLatestVersion": true,
+  "isLatestMajorVersion": true,
+  "checkinComment": "Updated version with corrections",
+  "previousVersionId": "PREVIOUS_VERSION_OBJECT_ID",
+  "properties": {},
+  "_links": {
+    "self": {"href": "/api/v1/repositories/bedroom/objects/NEW_VERSION_OBJECT_ID"},
+    "versionSeries": {"href": "/api/v1/repositories/bedroom/documents/VERSION_SERIES_ID/versions"},
+    "previousVersion": {"href": "/api/v1/repositories/bedroom/objects/PREVIOUS_VERSION_OBJECT_ID"},
+    "content": {"href": "/api/v1/repositories/bedroom/objects/NEW_VERSION_OBJECT_ID/content"}
+  }
+}
+```
+
+**POST /documents/{documentId}/cancelCheckout レスポンス:**
+
+```json
+{
+  "success": true,
+  "cancelledPwcId": "PWC_OBJECT_ID",
+  "restoredObjectId": "ORIGINAL_OBJECT_ID",
+  "versionSeriesId": "VERSION_SERIES_ID",
+  "isVersionSeriesCheckedOut": false,
+  "_links": {
+    "restoredObject": {"href": "/api/v1/repositories/bedroom/objects/ORIGINAL_OBJECT_ID"}
+  }
+}
+```
+
+#### 3.4.6 タイプ (`/api/v1/repositories/{repositoryId}/types`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/` | タイプ一覧取得 | getTypeChildren |
+| GET | `/{typeId}` | タイプ定義取得 | getTypeDefinition |
+| GET | `/{typeId}/children` | 子タイプ取得 | getTypeChildren |
+| GET | `/{typeId}/descendants` | 子孫タイプ取得 | getTypeDescendants |
+| GET | `/{typeId}/schema` | OpenAPI スキーマ取得 | - |
+| POST | `/` | タイプ作成 | createType |
+| PUT | `/{typeId}` | タイプ更新 | updateType |
+| DELETE | `/{typeId}` | タイプ削除 | deleteType |
+
+#### 3.4.7 ACL (`/api/v1/repositories/{repositoryId}/objects/{objectId}/acl`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/` | ACL 取得 | getAcl |
+| PUT | `/` | ACL 適用 | applyAcl |
+
+#### 3.4.8 リレーションシップ (`/api/v1/repositories/{repositoryId}/relationships`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | リレーションシップ作成 | createRelationship |
+| GET | `/object/{objectId}` | オブジェクトのリレーションシップ取得 | getObjectRelationships |
+
+#### 3.4.9 ポリシー (`/api/v1/repositories/{repositoryId}/policies`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | ポリシー作成 | createPolicy |
+| POST | `/apply` | ポリシー適用 | applyPolicy |
+| POST | `/remove` | ポリシー解除 | removePolicy |
+| GET | `/object/{objectId}` | 適用ポリシー取得 | getAppliedPolicies |
+
+#### 3.4.10 クエリ (`/api/v1/repositories/{repositoryId}/query`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | CMIS クエリ実行 | query |
+| GET | `/changes` | 変更ログ取得 | getContentChanges |
+
+#### 3.4.11 ユーザー (`/api/v1/repositories/{repositoryId}/users`)
+
+既存の `/rest/repo/{repositoryId}/user/` と同等の機能を OpenAPI 準拠で再設計。
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/` | ユーザー一覧取得 |
+| GET | `/{userId}` | ユーザー取得 |
+| GET | `/search` | ユーザー検索 |
+| POST | `/` | ユーザー作成 |
+| PUT | `/{userId}` | ユーザー更新 |
+| DELETE | `/{userId}` | ユーザー削除 |
+| POST | `/{userId}/password` | パスワード変更 |
+
+#### 3.4.12 グループ (`/api/v1/repositories/{repositoryId}/groups`)
+
+既存の `/rest/repo/{repositoryId}/group/` と同等の機能を OpenAPI 準拠で再設計。
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/` | グループ一覧取得 |
+| GET | `/{groupId}` | グループ取得 |
+| GET | `/search` | グループ検索 |
+| POST | `/` | グループ作成 |
+| PUT | `/{groupId}` | グループ更新 |
+| DELETE | `/{groupId}` | グループ削除 |
+| POST | `/{groupId}/members` | メンバー追加 |
+| DELETE | `/{groupId}/members` | メンバー削除 |
+
+#### 3.4.13 認証 (`/api/v1/auth`)
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| POST | `/login` | ログイン（トークン発行） |
+| POST | `/logout` | ログアウト（トークン無効化） |
+| POST | `/token/refresh` | トークンリフレッシュ |
+| POST | `/saml` | SAML 認証 |
+| POST | `/oidc` | OIDC 認証 |
+| GET | `/me` | 現在のユーザー情報取得 |
+
+### 3.5 共通仕様
+
+#### 3.5.1 認証
+
+```
+Authorization: Bearer {token}
+```
+
+または
+
+```
+Authorization: Basic {base64(username:password)}
+```
+
+#### 3.5.2 エラーレスポンス
+
+RFC 7807 (Problem Details for HTTP APIs) 準拠:
+
+```json
+{
+  "type": "https://nemakiware.org/errors/object-not-found",
+  "title": "Object Not Found",
+  "status": 404,
+  "detail": "The object with ID 'OBJECT_ID' was not found in repository 'bedroom'",
+  "instance": "/api/v1/repositories/bedroom/objects/OBJECT_ID"
+}
+```
+
+**エラーコード一覧:**
+
+| HTTP Status | Type | 説明 |
+|-------------|------|------|
+| 400 | invalid-argument | 不正なリクエストパラメータ |
+| 401 | unauthorized | 認証が必要 |
+| 403 | permission-denied | 権限不足 |
+| 404 | object-not-found | オブジェクトが見つからない |
+| 404 | type-not-found | タイプが見つからない |
+| 409 | conflict | 競合（名前重複、バージョン競合など） |
+| 409 | content-already-exists | コンテンツが既に存在 |
+| 409 | version-conflict | バージョン競合（changeToken 不一致） |
+| 422 | constraint-violation | 制約違反 |
+| 500 | internal-error | 内部エラー |
+| 503 | service-unavailable | サービス利用不可 |
+
+#### 3.5.3 ページネーション
+
+```json
+{
+  "items": [],
+  "hasMoreItems": true,
+  "numItems": 1000,
+  "pageInfo": {
+    "maxItems": 50,
+    "skipCount": 0
+  },
+  "_links": {
+    "self": {"href": "...?maxItems=50&skipCount=0"},
+    "first": {"href": "...?maxItems=50&skipCount=0"},
+    "next": {"href": "...?maxItems=50&skipCount=50"},
+    "last": {"href": "...?maxItems=50&skipCount=950"}
+  }
+}
+```
+
+#### 3.5.4 HATEOAS リンク
+
+全てのリソースレスポンスに `_links` セクションを含める:
+
+```json
+{
+  "_links": {
+    "self": {"href": "/api/v1/repositories/bedroom/objects/OBJECT_ID"},
+    "parent": {"href": "/api/v1/repositories/bedroom/folders/PARENT_ID"},
+    "children": {"href": "/api/v1/repositories/bedroom/folders/OBJECT_ID/children"},
+    "content": {"href": "/api/v1/repositories/bedroom/objects/OBJECT_ID/content"},
+    "acl": {"href": "/api/v1/repositories/bedroom/objects/OBJECT_ID/acl"},
+    "type": {"href": "/api/v1/repositories/bedroom/types/cmis:document"}
+  }
+}
+```
+
+---
+
+## 4. OData 4.0 設計
+
+### 4.1 概要
+
+OData (Open Data Protocol) 4.0 は、RESTful API の上に構築された標準プロトコルで、データのクエリと操作を標準化します。NemakiWare では、コンテンツリポジトリへの柔軟なアクセスを提供するために OData をサポートします。
+
+### 4.2 OData スコープ定義
+
+#### 4.2.1 サポート範囲
+
+| 機能カテゴリ | サポートレベル | 備考 |
+|-------------|---------------|------|
+| 読み取り操作 | 完全サポート | GET によるエンティティ/コレクション取得 |
+| 作成操作 | 完全サポート | POST によるエンティティ作成 |
+| 更新操作 | 完全サポート | PUT/PATCH によるプロパティ更新 |
+| 削除操作 | 完全サポート | DELETE によるエンティティ削除 |
+| アクション | 部分サポート | CheckOut, CheckIn, Move, Copy |
+| ファンクション | 部分サポート | GetAllVersions, GetObjectByPath, Query |
+| バッチ操作 | 初期リリースでは未サポート | 将来バージョンで検討 |
+
+#### 4.2.2 制限事項
+
+1. **バッチ操作**: `$batch` エンドポイントは初期リリースでは未サポート
+2. **デルタクエリ**: `$deltatoken` は未サポート（代わりに CMIS の getContentChanges を使用）
+3. **非同期操作**: `Prefer: respond-async` は未サポート
+
+### 4.3 エンドポイント構造
+
+```
+/odata/{repositoryId}/              # サービスルート
+/odata/{repositoryId}/$metadata     # メタデータドキュメント
+/odata/{repositoryId}/{EntitySet}   # エンティティセット
+```
+
+### 4.4 動的メタデータ生成
+
+#### 4.4.1 設計方針
+
+OData の `$metadata` エンドポイントは、CMIS タイプ定義に基づいて**動的に生成**されます。これにより、カスタムタイプが OData クライアントから正しく認識されます。
+
+**動的生成の仕組み:**
+1. 基本タイプ（Document, Folder, Relationship, Policy, Item）は常に存在
+2. カスタムタイプは派生 EntityType として動的に追加
+3. タイプ定義の変更時にメタデータを再生成
+4. ETag ヘッダーによるキャッシュ制御
+
+#### 4.4.2 メタデータキャッシュ
+
+```
+GET /odata/bedroom/$metadata
+If-None-Match: "TYPE_HASH_123"
+```
+
+**レスポンスヘッダー:**
+```
+ETag: "TYPE_HASH_456"
+Cache-Control: private, max-age=3600
+```
+
+タイプ定義が変更されると ETag が更新され、クライアントは新しいメタデータを取得します。
+
+### 4.5 エンティティセット
+
+| エンティティセット | 説明 | 対応 CMIS タイプ |
+|-------------------|------|-----------------|
+| Objects | 全オブジェクト | cmis:object |
+| Documents | ドキュメント | cmis:document |
+| Folders | フォルダ | cmis:folder |
+| Relationships | リレーションシップ | cmis:relationship |
+| Policies | ポリシー | cmis:policy |
+| Items | アイテム | cmis:item |
+| Types | タイプ定義 | - |
+| Users | ユーザー | nemaki:user |
+| Groups | グループ | nemaki:group |
+
+### 4.6 クエリオプション
+
+| オプション | 説明 | 例 |
+|-----------|------|-----|
+| $filter | フィルタ条件 | `$filter=name eq 'test.pdf'` |
+| $select | 取得プロパティ | `$select=objectId,name,creationDate` |
+| $expand | 関連エンティティ展開 | `$expand=parent,children` |
+| $orderby | ソート | `$orderby=creationDate desc` |
+| $top | 取得件数制限 | `$top=10` |
+| $skip | スキップ件数 | `$skip=20` |
+| $count | 件数取得 | `$count=true` |
+| $search | 全文検索 | `$search=invoice` |
+
+### 4.7 検索仕様（$search と CMIS Query の関係）
+
+#### 4.7.1 検索機能の整理
+
+| 検索方法 | 用途 | 実装 | 対応 |
+|---------|------|------|------|
+| `$search` | 全文検索（キーワード） | Solr 全文検索 | OData 標準 |
+| `$filter` | プロパティベースフィルタ | CMIS WHERE 句に変換 | OData 標準 |
+| `Query()` ファンクション | CMIS SQL 完全サポート | CMIS Query 直接実行 | NemakiWare 拡張 |
+
+#### 4.7.2 $search の動作
+
+`$search` は Solr の全文検索を使用し、ドキュメントのコンテンツとプロパティを検索します。
+
+```
+GET /odata/bedroom/Documents?$search=contract
+```
+
+**内部処理:**
+1. Solr に全文検索クエリを発行
+2. マッチしたオブジェクト ID を取得
+3. CMIS からオブジェクト情報を取得
+4. OData 形式でレスポンスを返却
+
+#### 4.7.3 $filter の動作
+
+`$filter` は CMIS Query の WHERE 句に変換されます。
+
+```
+GET /odata/bedroom/Documents?$filter=contentStreamMimeType eq 'application/pdf' and creationDate gt 2026-01-01T00:00:00Z
+```
+
+**変換後の CMIS Query:**
+```sql
+SELECT * FROM cmis:document WHERE cmis:contentStreamMimeType = 'application/pdf' AND cmis:creationDate > TIMESTAMP '2026-01-01T00:00:00.000Z'
+```
+
+#### 4.7.4 Query() ファンクションの動作
+
+CMIS SQL を直接実行する場合は `Query()` ファンクションを使用します。
+
+```
+GET /odata/bedroom/Query(statement='SELECT * FROM cmis:document WHERE CONTAINS("contract")',searchAllVersions=false,maxItems=100)
+```
+
+### 4.8 ACL/権限の表現
+
+#### 4.8.1 権限チェックの動作
+
+OData は標準的に ACL を持たないため、NemakiWare では以下の動作を定義します。
+
+| シナリオ | HTTP Status | 動作 |
+|---------|-------------|------|
+| 特定オブジェクトへのアクセス権限なし | 403 Forbidden | エラーレスポンスを返却 |
+| オブジェクトが存在しない | 404 Not Found | エラーレスポンスを返却 |
+| コレクション取得時に権限のないオブジェクト | - | 結果から除外（エラーなし） |
+
+#### 4.8.2 コレクション取得時の権限フィルタ
+
+`$filter` や `$search` でコレクションを取得する場合、ユーザーが読み取り権限を持つオブジェクトのみが返されます。
+
+**レスポンスヘッダー:**
+```
+X-Total-Count: 150
+X-Accessible-Count: 120
+```
+
+- `X-Total-Count`: フィルタ条件にマッチした総件数（権限チェック前）
+- `X-Accessible-Count`: ユーザーがアクセス可能な件数
+
+**注意:** `X-Total-Count` は管理者のみに返却されます。一般ユーザーには `X-Accessible-Count` のみが返却されます。
+
+#### 4.8.3 権限エラーレスポンス
+
+```json
+{
+  "error": {
+    "code": "PermissionDenied",
+    "message": "You do not have permission to access this object",
+    "target": "Documents('OBJECT_ID')",
+    "details": [
+      {
+        "code": "InsufficientPermission",
+        "message": "Required permission: cmis:read"
+      }
+    ]
+  }
+}
+```
+
+### 4.9 アクションとファンクション
+
+#### 4.9.1 アクション（副作用あり）
+
+| アクション | 説明 | バインド先 |
+|-----------|------|-----------|
+| CheckOut | チェックアウト | Document |
+| CancelCheckOut | チェックアウト取消 | Document |
+| CheckIn | チェックイン | Document |
+| Move | 移動 | Object |
+| Copy | コピー | Document |
+| ApplyAcl | ACL 適用 | Object |
+
+**例:**
+```
+POST /odata/bedroom/Documents('OBJECT_ID')/NemakiWare.CMIS.CheckOut
+```
+
+#### 4.9.2 ファンクション（副作用なし）
+
+| ファンクション | 説明 | バインド先 |
+|---------------|------|-----------|
+| GetAllVersions | 全バージョン取得 | Document |
+| GetObjectByPath | パスでオブジェクト取得 | EntitySet |
+| Query | CMIS クエリ実行 | EntitySet |
+
+**例:**
+```
+GET /odata/bedroom/Documents('OBJECT_ID')/NemakiWare.CMIS.GetAllVersions()
+GET /odata/bedroom/GetObjectByPath(path='/folder/document.pdf')
+GET /odata/bedroom/Query(statement='SELECT * FROM cmis:document',maxItems=100)
+```
+
+---
+
+## 5. API 互換性ポリシー
+
+### 5.1 バージョニング方針
+
+#### 5.1.1 セマンティックバージョニング
+
+API バージョンは URL パスに含まれ、セマンティックバージョニングに従います。
+
+```
+/api/v1/...  # メジャーバージョン 1
+/api/v2/...  # メジャーバージョン 2（将来）
+```
+
+#### 5.1.2 バージョン間の互換性
+
+| 変更タイプ | 互換性 | 例 |
+|-----------|--------|-----|
+| 新規エンドポイント追加 | 後方互換 | 新しいリソースの追加 |
+| 新規オプションパラメータ追加 | 後方互換 | クエリパラメータの追加 |
+| 新規レスポンスフィールド追加 | 後方互換 | JSON フィールドの追加 |
+| 必須パラメータの追加 | 破壊的変更 | メジャーバージョンアップ必要 |
+| エンドポイントの削除 | 破壊的変更 | メジャーバージョンアップ必要 |
+| レスポンス形式の変更 | 破壊的変更 | メジャーバージョンアップ必要 |
+
+### 5.2 非推奨ポリシー
+
+#### 5.2.1 非推奨の通知
+
+非推奨となった機能は、レスポンスヘッダーで通知されます。
+
+```
+Deprecation: true
+Sunset: Sat, 01 Jan 2028 00:00:00 GMT
+Link: </api/v2/...>; rel="successor-version"
+```
+
+#### 5.2.2 非推奨期間
+
+- 非推奨から削除まで: 最低 2 メジャーリリース（約 12 ヶ月）
+- 非推奨期間中は機能は維持される
+- 削除予定日は `Sunset` ヘッダーで通知
+
+### 5.3 既存 REST API との互換性
+
+#### 5.3.1 互換性方針
+
+**明確な方針: `/rest/` と `/api/v1/` は互換性なし**
+
+| 項目 | `/rest/` (既存) | `/api/v1/` (新規) |
+|------|----------------|-------------------|
+| レスポンス形式 | 独自形式 | OpenAPI 準拠 |
+| エラー形式 | 独自形式 | RFC 7807 準拠 |
+| プロパティ表現 | フラット | 2層構造（value/type） |
+| ページネーション | 独自形式 | 標準形式 |
+
+#### 5.3.2 移行サポート
+
+1. `/rest/` エンドポイントは維持（非推奨化なし）
+2. 新規開発は `/api/v1/` を推奨
+3. 移行ガイドを提供（セクション 8 参照）
+
+---
+
+## 6. OpenAPI スキーマ戦略
+
+### 6.1 スキーマ設計方針
+
+#### 6.1.1 基本タイプのスキーマ
+
+CMIS 標準タイプ（cmis:document, cmis:folder 等）は静的スキーマとして定義します。
+
+```yaml
+components:
+  schemas:
+    CmisObject:
+      type: object
+      required:
+        - objectId
+        - objectTypeId
+        - baseTypeId
+      properties:
+        objectId:
+          type: string
+        objectTypeId:
+          type: string
+        baseTypeId:
+          type: string
+        properties:
+          $ref: '#/components/schemas/PropertyMap'
+        allowableActions:
+          $ref: '#/components/schemas/AllowableActions'
+        _links:
+          $ref: '#/components/schemas/Links'
+
+    PropertyMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/PropertyValue'
+
+    PropertyValue:
+      type: object
+      required:
+        - value
+        - type
+      properties:
+        value:
+          oneOf:
+            - type: string
+            - type: number
+            - type: boolean
+            - type: array
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+                  - type: boolean
+        type:
+          type: string
+          enum:
+            - string
+            - boolean
+            - integer
+            - decimal
+            - datetime
+            - uri
+            - id
+            - html
+        displayName:
+          type: string
+        cardinality:
+          type: string
+          enum:
+            - single
+            - multi
+```
+
+#### 6.1.2 カスタムタイプのスキーマ
+
+カスタムタイプは動的スキーマ生成エンドポイントで取得します。
+
+```
+GET /api/v1/repositories/{repositoryId}/types/{typeId}/schema
+```
+
+### 6.2 SDK 生成における不確実性の取り扱い
+
+#### 6.2.1 推奨ワークフロー
+
+1. **静的 SDK 生成**: 基本 OpenAPI 仕様から SDK を生成
+2. **動的型情報取得**: 実行時にタイプ定義 API から型情報を取得
+3. **型安全なアクセス**: 取得した型情報を使用してプロパティにアクセス
+
+#### 6.2.2 SDK 生成時の注意事項
+
+```yaml
+# openapi.yaml での注釈
+x-nemakiware-dynamic-properties:
+  description: |
+    The 'properties' field contains dynamic properties based on the object's type.
+    Use the /types/{typeId}/schema endpoint to get the exact schema for a specific type.
+    SDK generators should treat this as a generic map and provide helper methods
+    for type-safe property access.
+```
+
+---
+
+## 7. 実装計画
+
+### 7.1 技術スタック
+
+| コンポーネント | 技術 | 備考 |
+|---------------|------|------|
+| REST フレームワーク | Jersey (JAX-RS) | 既存と同じ |
+| OpenAPI 生成 | Swagger/OpenAPI 3.0 | swagger-jaxrs2 |
+| OData ライブラリ | Apache Olingo 4.x | OData 4.0 対応 |
+| JSON 処理 | Jackson | 既存と同じ |
+| ドキュメント UI | Swagger UI | API ドキュメント |
+| REST テスト | REST Assured | 流暢な API テスト |
+| OData テスト | Apache Olingo Client | OData クライアントテスト |
+| API 仕様検証 | Swagger Request Validator | OpenAPI 仕様との整合性検証 |
+
+### 7.2 フェーズ分け
+
+#### フェーズ 1: OpenAPI 基盤整備（2-3週間）
+
+1. OpenAPI 3.0 仕様ファイル（openapi.yaml）の作成
+2. Swagger UI の統合
+3. 共通エラーハンドリングの実装
+4. 認証フィルタの整備
+5. プロパティ 2 層構造の DTO 実装
+
+#### フェーズ 2: CMIS 操作の REST 化（4-6週間）
+
+1. ObjectService の REST 化
+   - オブジェクト CRUD
+   - コンテンツストリーム操作（Raw Binary / Multipart 対応）
+2. NavigationService の REST 化
+   - フォルダナビゲーション
+3. VersioningService の REST 化
+   - チェックアウト/チェックイン（レスポンス形式の明確化）
+4. DiscoveryService の REST 化
+   - クエリ実行
+5. その他サービスの REST 化
+
+#### フェーズ 3: OData 対応（3-4週間）
+
+1. Apache Olingo の統合
+2. 動的メタデータ生成の実装
+3. OData サービスプロバイダの実装
+4. クエリオプションの実装（$filter → CMIS Query 変換）
+5. $search と Solr の統合
+6. アクション/ファンクションの実装
+7. 権限フィルタの実装
+
+#### フェーズ 4: テストと文書化（2-3週間）
+
+1. 単体テスト
+2. 統合テスト
+3. OData 準拠テスト（セクション 9 参照）
+4. API ドキュメントの完成
+5. マイグレーションガイドの作成
+
+### 7.3 ディレクトリ構造
+
+```
+core/src/main/java/jp/aegif/nemaki/
+├── api/                          # 新規 OpenAPI REST API
+│   ├── v1/
+│   │   ├── ApiApplication.java   # JAX-RS Application
+│   │   ├── resource/
+│   │   │   ├── RepositoryResource.java
+│   │   │   ├── ObjectResource.java
+│   │   │   ├── FolderResource.java
+│   │   │   ├── DocumentResource.java
+│   │   │   ├── TypeResource.java
+│   │   │   ├── AclResource.java
+│   │   │   ├── QueryResource.java
+│   │   │   ├── UserResource.java
+│   │   │   ├── GroupResource.java
+│   │   │   └── AuthResource.java
+│   │   ├── model/
+│   │   │   ├── PropertyValue.java    # 2層構造プロパティ
+│   │   │   ├── request/              # リクエスト DTO
+│   │   │   └── response/             # レスポンス DTO
+│   │   ├── filter/
+│   │   │   ├── AuthenticationFilter.java
+│   │   │   └── CorsFilter.java
+│   │   └── exception/
+│   │       ├── ApiExceptionMapper.java
+│   │       └── ProblemDetail.java
+│   └── odata/
+│       ├── ODataServlet.java
+│       ├── NemakiEdmProvider.java        # 動的メタデータ生成
+│       ├── NemakiEntityCollectionProcessor.java
+│       ├── NemakiEntityProcessor.java
+│       ├── NemakiActionProcessor.java
+│       ├── NemakiSearchHandler.java      # $search 処理
+│       └── NemakiPermissionFilter.java   # 権限フィルタ
+├── rest/                         # 既存 REST API（維持）
+├── cmis/                         # 既存 CMIS 実装
+└── businesslogic/                # ビジネスロジック
+```
+
+---
+
+## 8. 移行ガイドライン
+
+### 8.1 既存 REST API からの移行
+
+#### 8.1.1 エンドポイントマッピング
+
+| 既存パス | 新規パス | 変更点 |
+|---------|---------|--------|
+| `/rest/repo/{repoId}/user/list` | `/api/v1/repositories/{repoId}/users` | GET メソッド、レスポンス形式 |
+| `/rest/repo/{repoId}/user/show/{id}` | `/api/v1/repositories/{repoId}/users/{id}` | パス構造 |
+| `/rest/repo/{repoId}/user/create/{id}` | `/api/v1/repositories/{repoId}/users` | POST メソッド、ID は自動生成可 |
+| `/rest/repo/{repoId}/group/list` | `/api/v1/repositories/{repoId}/groups` | GET メソッド、レスポンス形式 |
+| `/rest/repo/{repoId}/type/list` | `/api/v1/repositories/{repoId}/types` | GET メソッド、レスポンス形式 |
+| `/rest/repo/{repoId}/node/{id}/acl` | `/api/v1/repositories/{repoId}/objects/{id}/acl` | パス構造 |
+
+#### 8.1.2 レスポンス形式の変更
+
+**既存 REST API:**
+```json
+{
+  "status": "success",
+  "user": {
+    "userId": "user1",
+    "userName": "User One",
+    "email": "user1@example.com"
+  }
+}
+```
+
+**新規 REST API:**
+```json
+{
+  "userId": "user1",
+  "userName": "User One",
+  "email": "user1@example.com",
+  "_links": {
+    "self": {"href": "/api/v1/repositories/bedroom/users/user1"}
+  }
+}
+```
+
+### 8.2 CMIS バインディングからの移行
+
+CMIS Browser Binding と新規 REST API の対応:
+
+| CMIS Browser Binding | 新規 REST API |
+|---------------------|---------------|
+| `GET /browser/{repoId}/root?cmisselector=children` | `GET /api/v1/repositories/{repoId}/folders/{folderId}/children` |
+| `POST /browser/{repoId}?cmisaction=createDocument` | `POST /api/v1/repositories/{repoId}/documents` |
+| `GET /browser/{repoId}/root?cmisselector=object&objectId=xxx` | `GET /api/v1/repositories/{repoId}/objects/{objectId}` |
+| `POST /browser/{repoId}?cmisaction=checkOut&objectId=xxx` | `POST /api/v1/repositories/{repoId}/documents/{documentId}/checkout` |
+| `POST /browser/{repoId}?cmisaction=checkIn&objectId=xxx` | `POST /api/v1/repositories/{repoId}/documents/{documentId}/checkin` |
+| `POST /browser/{repoId}?cmisaction=query` | `POST /api/v1/repositories/{repoId}/query` |
+
+### 8.3 後方互換性
+
+- 既存の `/rest/` エンドポイントは維持（非推奨化なし）
+- 既存の CMIS バインディング（`/atom/`, `/browser/`）は維持
+- 新規開発は `/api/v1/` を推奨
+
+---
+
+## 9. テスト計画
+
+### 9.1 単体テスト
+
+- 各 Resource クラスのテスト
+- DTO 変換のテスト（特にプロパティ 2 層構造）
+- バリデーションのテスト
+- エラーハンドリングのテスト
+
+### 9.2 統合テスト
+
+- エンドツーエンドの API テスト
+- 認証・認可のテスト
+- OData クエリのテスト
+- コンテンツストリーム操作のテスト
+
+### 9.3 OData 準拠テスト
+
+#### 9.3.1 テスト戦略
+
+OData には CMIS TCK のような単一公式 TCK がないため、以下の戦略でテストを実施します。
+
+#### 9.3.2 $metadata 検証
+
+1. **スキーマ検証**: OData CSDL スキーマに対する検証
+2. **動的生成検証**: カスタムタイプ追加後のメタデータ再生成確認
+3. **ETag 検証**: キャッシュ制御の動作確認
+
+```java
+@Test
+void testMetadataValidation() {
+    // $metadata を取得
+    String metadata = client.getMetadata();
+    
+    // OData CSDL スキーマに対して検証
+    CsdlValidator.validate(metadata);
+    
+    // 必須要素の存在確認
+    assertContains(metadata, "EntityType Name=\"Document\"");
+    assertContains(metadata, "EntitySet Name=\"Documents\"");
+}
+```
+
+#### 9.3.3 クエリオプションテスト
+
+| テスト項目 | テスト内容 |
+|-----------|-----------|
+| $filter | 各演算子（eq, ne, gt, lt, contains 等）の動作確認 |
+| $select | プロパティ選択の動作確認 |
+| $expand | ナビゲーションプロパティ展開の動作確認 |
+| $orderby | ソート（昇順/降順）の動作確認 |
+| $top/$skip | ページネーションの動作確認 |
+| $count | 件数取得の動作確認 |
+| $search | 全文検索の動作確認 |
+
+```java
+@Test
+void testFilterOperators() {
+    // eq 演算子
+    var result = client.get("/odata/bedroom/Documents?$filter=name eq 'test.pdf'");
+    assertEquals(1, result.getValue().size());
+    
+    // contains 演算子
+    result = client.get("/odata/bedroom/Documents?$filter=contains(name,'test')");
+    assertTrue(result.getValue().size() > 0);
+    
+    // 複合条件
+    result = client.get("/odata/bedroom/Documents?$filter=name eq 'test.pdf' and creationDate gt 2026-01-01T00:00:00Z");
+    // ...
+}
+```
+
+#### 9.3.4 結果整合性テスト
+
+OData API と既存 CMIS/REST API の結果を比較し、整合性を確認します。
+
+```java
+@Test
+void testResultConsistency() {
+    // OData で取得
+    var odataResult = odataClient.get("/odata/bedroom/Documents('DOC_ID')");
+    
+    // CMIS で取得
+    var cmisResult = cmisSession.getObject("DOC_ID");
+    
+    // プロパティの整合性確認
+    assertEquals(cmisResult.getName(), odataResult.getProperty("name"));
+    assertEquals(cmisResult.getCreatedBy(), odataResult.getProperty("createdBy"));
+}
+```
+
+#### 9.3.5 OData クライアントライブラリテスト
+
+複数の OData クライアントライブラリでの動作確認:
+
+1. **Simple.OData.Client** (.NET)
+2. **Apache Olingo Client** (Java)
+3. **datajs** (JavaScript)
+
+### 9.4 互換性テスト
+
+- 既存 REST API との互換性（並行稼働確認）
+- CMIS TCK との互換性（既存機能の維持確認）
+
+---
+
+## 10. セキュリティ考慮事項
+
+### 10.1 認証
+
+1. **Bearer Token 認証**: JWT ベースのトークン認証
+2. **Basic 認証**: 後方互換性のため維持
+3. **SAML/OIDC**: エンタープライズ SSO 対応
+
+### 10.2 認可
+
+1. **CMIS ACL**: オブジェクトレベルのアクセス制御
+2. **API レベル認可**: 管理者専用エンドポイントの保護
+3. **リポジトリアクセス制御**: リポジトリ単位のアクセス制限
+
+### 10.3 入力検証
+
+1. **パラメータ検証**: OpenAPI スキーマに基づく検証
+2. **CMIS 制約チェック**: タイプ定義に基づく検証
+3. **サニタイズ**: XSS/インジェクション対策
+
+### 10.4 レート制限
+
+1. **API レート制限**: 過負荷防止
+2. **クエリ制限**: 大量データ取得の制限
+
+---
+
+## 11. 変更履歴
+
+| バージョン | 日付 | 変更内容 | 作成者 |
+|-----------|------|---------|--------|
+| 1.0 | 2026-01-19 | 初版作成 | Devin |
+| 1.1 | 2026-01-19 | レビューフィードバック反映 | Devin |
+|     |            | - プロパティ 2 層構造の明確化 |  |
+|     |            | - Object/Document/Folder 境界の整理 |  |
+|     |            | - バージョニングレスポンス形式の明確化 |  |
+|     |            | - Content Stream 形式の明確化 |  |
+|     |            | - OData 動的メタデータ生成の追加 |  |
+|     |            | - OData 権限処理の明確化 |  |
+|     |            | - $search と CMIS Query の関係整理 |  |
+|     |            | - 移行互換性ポリシーの明確化 |  |
+|     |            | - OData テスト戦略の具体化 |  |
+|     |            | - API 互換性ポリシーセクション追加 |  |
+|     |            | - OData スコープ定義セクション追加 |  |
+|     |            | - OpenAPI スキーマ戦略セクション追加 |  |
+|     |            | - テストツール（REST Assured, Olingo Client）追加 |  |
+
+---
+
+*本設計書は NemakiWare プロジェクトの一部として GNU AGPL v3 ライセンスの下で公開されます。*


### PR DESCRIPTION
### Motivation

- Provide a first-phase OpenAPI 3.0 compliant REST API surface (`/api/v1`) for NemakiWare with Swagger support and a foundation for OData integration.
- Introduce RFC 7807-compliant error handling and consistent JSON serialization for the new API to improve client interoperability.
- Add DTOs and resource scaffolding to represent CMIS concepts in a stable OpenAPI-friendly shape, including HATEOAS links for navigability.
- Add build dependencies and documentation to support API generation, testing and OData future work.

### Description

- Added a JAX-RS application entrypoint `ApiV1Application` that registers the new API stack and exposes the OpenAPI resource and annotations for `/api/v1`.
- Introduced JSON configuration via `ApiJacksonProvider` and CORS/auth filters via `ApiCorsFilter` and `ApiAuthenticationFilter` to standardize request/response handling and cross-origin support.
- Implemented RFC 7807 error model and mapping with `ProblemDetail`, `ApiException`, `ApiExceptionMapper`, and `ValidationExceptionMapper` for consistent error responses.
- Added domain DTOs and resource implementation for repository APIs, including `PropertyValue`, `LinkInfo`, `RepositoryInfoResponse`, `RepositoryCapabilities`, `AclCapabilities`, and the `RepositoryResource` resource class.
- Updated `core/pom.xml` to include OpenAPI/Swagger, REST Assured, Apache Olingo and Jakarta Validation dependencies needed for the API, testing and future OData work.
- Added a comprehensive design document `docs/design/REST-API-ODATA-DESIGN.md` describing URL structure, resource design, OData approach, schema strategy and a phased implementation/test plan.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d906848e48322abf0ce841ebc6698)