### PR TITLE
fix(api-v1): synchronize datetime parsing to avoid SimpleDateFormat concurrency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -760,6 +760,83 @@
 			<artifactId>jakarta.jws-api</artifactId>
 			<version>3.0.0</version>
 		</dependency>
+
+		<!-- OpenAPI/Swagger Dependencies for REST API v1 -->
+		<!-- Swagger Core for OpenAPI 3.0 annotations and specification -->
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-jaxrs2-jakarta</artifactId>
+			<version>2.2.25</version>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-annotations-jakarta</artifactId>
+			<version>2.2.25</version>
+		</dependency>
+
+		<!-- REST Assured for API testing -->
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Swagger Request Validator for OpenAPI compliance testing -->
+		<dependency>
+			<groupId>com.atlassian.oai</groupId>
+			<artifactId>swagger-request-validator-restassured</artifactId>
+			<version>2.40.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Apache Olingo for OData 4.0 support -->
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-server-core</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-server-api</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-commons-core</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-commons-api</artifactId>
+			<version>4.10.0</version>
+		</dependency>
+
+		<!-- Apache Olingo Client for OData testing -->
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-client-core</artifactId>
+			<version>4.10.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.olingo</groupId>
+			<artifactId>odata-client-api</artifactId>
+			<version>4.10.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Jakarta Validation for request validation -->
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>8.0.1.Final</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/ApiJacksonProvider.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/ApiJacksonProvider.java
@@ -1,0 +1,37 @@
+package jp.aegif.nemaki.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class ApiJacksonProvider implements ContextResolver<ObjectMapper> {
+    
+    private final ObjectMapper objectMapper;
+    
+    public ApiJacksonProvider() {
+        objectMapper = new ObjectMapper();
+        
+        // Configure for ISO 8601 date format
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        
+        // Pretty print for readability
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        
+        // Don't fail on unknown properties (forward compatibility)
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        
+        // Include non-null values only
+        objectMapper.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL);
+    }
+    
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return objectMapper;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/ApiV1Application.java
@@ -1,0 +1,97 @@
+package jp.aegif.nemaki.api.v1;
+
+import java.util.logging.Logger;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.spring.SpringLifecycleListener;
+import org.glassfish.jersey.server.spring.SpringComponentProvider;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.jackson.JacksonFeature;
+
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.ws.rs.ApplicationPath;
+
+@ApplicationPath("/api/v1")
+@OpenAPIDefinition(
+    info = @Info(
+        title = "NemakiWare REST API",
+        version = "1.0.0",
+        description = "OpenAPI 3.0 compliant REST API for NemakiWare CMIS Repository. " +
+                      "This API provides full access to CMIS operations including object management, " +
+                      "versioning, navigation, and query capabilities.",
+        contact = @Contact(
+            name = "NemakiWare Project",
+            url = "https://github.com/aegif/NemakiWare"
+        ),
+        license = @License(
+            name = "GNU AGPL v3",
+            url = "https://www.gnu.org/licenses/agpl-3.0.html"
+        )
+    ),
+    servers = {
+        @Server(url = "/core/api/v1", description = "NemakiWare REST API v1")
+    },
+    tags = {
+        @Tag(name = "repositories", description = "Repository management operations"),
+        @Tag(name = "objects", description = "Generic object operations (canonical endpoint)"),
+        @Tag(name = "documents", description = "Document-specific operations including versioning"),
+        @Tag(name = "folders", description = "Folder-specific operations and navigation"),
+        @Tag(name = "types", description = "Type definition management"),
+        @Tag(name = "acl", description = "Access control list operations"),
+        @Tag(name = "query", description = "CMIS query operations"),
+        @Tag(name = "users", description = "User management operations"),
+        @Tag(name = "groups", description = "Group management operations"),
+        @Tag(name = "auth", description = "Authentication operations")
+    }
+)
+public class ApiV1Application extends ResourceConfig {
+    
+    private static final Logger logger = Logger.getLogger(ApiV1Application.class.getName());
+
+    public ApiV1Application() {
+        logger.info("=== Initializing NemakiWare API v1 Application ===");
+        
+        // Enable Jersey-Spring integration
+        register(SpringLifecycleListener.class);
+        register(SpringComponentProvider.class);
+        
+        // Enable multipart support for content stream uploads
+        register(MultiPartFeature.class);
+        
+        // Enable JSON processing with Jackson
+        register(JacksonFeature.class);
+        
+        // Register custom Jackson provider for unified ObjectMapper
+        register(jp.aegif.nemaki.api.v1.ApiJacksonProvider.class);
+        
+        // Register OpenAPI/Swagger resource for /openapi.json endpoint
+        register(OpenApiResource.class);
+        
+        // Register exception mappers for RFC 7807 compliant error responses
+        register(jp.aegif.nemaki.api.v1.exception.ApiExceptionMapper.class);
+        register(jp.aegif.nemaki.api.v1.exception.ValidationExceptionMapper.class);
+        
+        // Register authentication filter
+        register(jp.aegif.nemaki.api.v1.filter.ApiAuthenticationFilter.class);
+        
+        // Note: CORS is handled by SimpleCorsFilter in web.xml to avoid duplicate headers
+        // Do NOT register ApiCorsFilter here as it would cause double CORS header application
+        
+        // Enable Jersey-Spring bridge for automatic DI
+        property("jersey.config.server.provider.classnames", 
+                "org.glassfish.jersey.server.spring.SpringLifecycleListener," +
+                "org.glassfish.jersey.server.spring.scope.RequestContextFilter");
+        
+        // Enable automatic package scanning for REST resources
+        packages("jp.aegif.nemaki.api.v1.resource");
+        
+        logger.info("=== NemakiWare API v1 Application initialized successfully ===");
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiException.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiException.java
@@ -1,0 +1,108 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+public class ApiException extends RuntimeException {
+    
+    private final ProblemDetail problemDetail;
+    
+    public ApiException(ProblemDetail problemDetail) {
+        super(problemDetail.getDetail());
+        this.problemDetail = problemDetail;
+    }
+    
+    public ApiException(ProblemDetail problemDetail, Throwable cause) {
+        super(problemDetail.getDetail(), cause);
+        this.problemDetail = problemDetail;
+    }
+    
+    public ProblemDetail getProblemDetail() {
+        return problemDetail;
+    }
+    
+    public int getStatus() {
+        return problemDetail.getStatus();
+    }
+    
+    public static ApiException invalidArgument(String detail) {
+        return new ApiException(ProblemDetail.invalidArgument(detail));
+    }
+    
+    public static ApiException invalidArgument(String detail, String instance) {
+        return new ApiException(ProblemDetail.invalidArgument(detail, instance));
+    }
+    
+    public static ApiException unauthorized(String detail) {
+        return new ApiException(ProblemDetail.unauthorized(detail));
+    }
+    
+    public static ApiException unauthorized(String detail, String instance) {
+        return new ApiException(ProblemDetail.unauthorized(detail, instance));
+    }
+    
+    public static ApiException permissionDenied(String detail) {
+        return new ApiException(ProblemDetail.permissionDenied(detail));
+    }
+    
+    public static ApiException permissionDenied(String detail, String instance) {
+        return new ApiException(ProblemDetail.permissionDenied(detail, instance));
+    }
+    
+    public static ApiException objectNotFound(String objectId, String repositoryId) {
+        return new ApiException(ProblemDetail.objectNotFound(objectId, repositoryId));
+    }
+    
+    public static ApiException objectNotFound(String objectId, String repositoryId, String instance) {
+        return new ApiException(ProblemDetail.objectNotFound(objectId, repositoryId, instance));
+    }
+    
+    public static ApiException typeNotFound(String typeId, String repositoryId) {
+        return new ApiException(ProblemDetail.typeNotFound(typeId, repositoryId));
+    }
+    
+    public static ApiException repositoryNotFound(String repositoryId) {
+        return new ApiException(ProblemDetail.repositoryNotFound(repositoryId));
+    }
+    
+    public static ApiException userNotFound(String userId, String repositoryId) {
+        return new ApiException(ProblemDetail.userNotFound(userId, repositoryId));
+    }
+    
+    public static ApiException groupNotFound(String groupId, String repositoryId) {
+        return new ApiException(ProblemDetail.groupNotFound(groupId, repositoryId));
+    }
+    
+    public static ApiException conflict(String detail) {
+        return new ApiException(ProblemDetail.conflict(detail));
+    }
+    
+    public static ApiException conflict(String detail, String instance) {
+        return new ApiException(ProblemDetail.conflict(detail, instance));
+    }
+    
+    public static ApiException contentAlreadyExists(String objectId) {
+        return new ApiException(ProblemDetail.contentAlreadyExists(objectId));
+    }
+    
+    public static ApiException versionConflict(String objectId, String expectedToken, String actualToken) {
+        return new ApiException(ProblemDetail.versionConflict(objectId, expectedToken, actualToken));
+    }
+    
+    public static ApiException constraintViolation(String detail) {
+        return new ApiException(ProblemDetail.constraintViolation(detail));
+    }
+    
+    public static ApiException constraintViolation(String detail, String instance) {
+        return new ApiException(ProblemDetail.constraintViolation(detail, instance));
+    }
+    
+    public static ApiException internalError(String detail) {
+        return new ApiException(ProblemDetail.internalError(detail));
+    }
+    
+    public static ApiException internalError(String detail, Throwable cause) {
+        return new ApiException(ProblemDetail.internalError(detail), cause);
+    }
+    
+    public static ApiException serviceUnavailable(String detail) {
+        return new ApiException(ProblemDetail.serviceUnavailable(detail));
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiExceptionMapper.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ApiExceptionMapper.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.apache.chemistry.opencmis.commons.exceptions.CmisBaseException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisPermissionDeniedException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisInvalidArgumentException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisConstraintException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisContentAlreadyExistsException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisUpdateConflictException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisUnauthorizedException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Provider
+public class ApiExceptionMapper implements ExceptionMapper<Throwable> {
+    
+    private static final Logger logger = Logger.getLogger(ApiExceptionMapper.class.getName());
+    private static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+    
+    @Override
+    public Response toResponse(Throwable exception) {
+        ProblemDetail problemDetail;
+        
+        if (exception instanceof ApiException) {
+            problemDetail = ((ApiException) exception).getProblemDetail();
+        } else if (exception instanceof CmisObjectNotFoundException) {
+            problemDetail = ProblemDetail.objectNotFound(
+                    extractObjectId((CmisObjectNotFoundException) exception),
+                    "unknown");
+        } else if (exception instanceof CmisPermissionDeniedException) {
+            problemDetail = ProblemDetail.permissionDenied(exception.getMessage());
+        } else if (exception instanceof CmisUnauthorizedException) {
+            problemDetail = ProblemDetail.unauthorized(exception.getMessage());
+        } else if (exception instanceof CmisInvalidArgumentException) {
+            problemDetail = ProblemDetail.invalidArgument(exception.getMessage());
+        } else if (exception instanceof CmisConstraintException) {
+            problemDetail = ProblemDetail.constraintViolation(exception.getMessage());
+        } else if (exception instanceof CmisContentAlreadyExistsException) {
+            problemDetail = ProblemDetail.contentAlreadyExists("unknown");
+            problemDetail.setDetail(exception.getMessage());
+        } else if (exception instanceof CmisUpdateConflictException) {
+            problemDetail = ProblemDetail.conflict(exception.getMessage());
+        } else if (exception instanceof CmisBaseException) {
+            CmisBaseException cmisEx = (CmisBaseException) exception;
+            problemDetail = mapCmisException(cmisEx);
+        } else if (exception instanceof IllegalArgumentException) {
+            problemDetail = ProblemDetail.invalidArgument(exception.getMessage());
+        } else {
+            logger.log(Level.SEVERE, "Unexpected exception in API", exception);
+            problemDetail = ProblemDetail.internalError(
+                    "An unexpected error occurred: " + exception.getMessage());
+        }
+        
+        return Response.status(problemDetail.getStatus())
+                .type(PROBLEM_JSON_MEDIA_TYPE)
+                .entity(problemDetail)
+                .build();
+    }
+    
+    private ProblemDetail mapCmisException(CmisBaseException cmisEx) {
+        int httpStatus = cmisEx.getCode() != null ? cmisEx.getCode().intValue() : 500;
+        String errorName = cmisEx.getExceptionName();
+        
+        if (httpStatus >= 400 && httpStatus < 500) {
+            if (httpStatus == 400) {
+                return ProblemDetail.invalidArgument(cmisEx.getMessage());
+            } else if (httpStatus == 401) {
+                return ProblemDetail.unauthorized(cmisEx.getMessage());
+            } else if (httpStatus == 403) {
+                return ProblemDetail.permissionDenied(cmisEx.getMessage());
+            } else if (httpStatus == 404) {
+                return new ProblemDetail("not-found", "Not Found", 404, cmisEx.getMessage());
+            } else if (httpStatus == 409) {
+                return ProblemDetail.conflict(cmisEx.getMessage());
+            } else {
+                return new ProblemDetail("client-error", errorName, httpStatus, cmisEx.getMessage());
+            }
+        } else {
+            return ProblemDetail.internalError(cmisEx.getMessage());
+        }
+    }
+    
+    private String extractObjectId(CmisObjectNotFoundException ex) {
+        String message = ex.getMessage();
+        if (message != null && message.contains("'")) {
+            int start = message.indexOf("'");
+            int end = message.indexOf("'", start + 1);
+            if (end > start) {
+                return message.substring(start + 1, end);
+            }
+        }
+        return "unknown";
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ProblemDetail.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ProblemDetail.java
@@ -1,0 +1,208 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.net.URI;
+import java.util.Map;
+
+@Schema(description = "RFC 7807 Problem Details for HTTP APIs")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProblemDetail {
+    
+    private static final String BASE_TYPE_URI = "https://nemakiware.org/errors/";
+    
+    @Schema(description = "A URI reference that identifies the problem type",
+            example = "https://nemakiware.org/errors/object-not-found")
+    @JsonProperty("type")
+    private String type;
+    
+    @Schema(description = "A short, human-readable summary of the problem type",
+            example = "Object Not Found")
+    @JsonProperty("title")
+    private String title;
+    
+    @Schema(description = "The HTTP status code",
+            example = "404")
+    @JsonProperty("status")
+    private int status;
+    
+    @Schema(description = "A human-readable explanation specific to this occurrence of the problem",
+            example = "The object with ID 'OBJECT_ID' was not found in repository 'bedroom'")
+    @JsonProperty("detail")
+    private String detail;
+    
+    @Schema(description = "A URI reference that identifies the specific occurrence of the problem",
+            example = "/api/v1/repositories/bedroom/objects/OBJECT_ID")
+    @JsonProperty("instance")
+    private String instance;
+    
+    @Schema(description = "Additional properties specific to the error type")
+    @JsonProperty("extensions")
+    private Map<String, Object> extensions;
+    
+    public ProblemDetail() {
+    }
+    
+    public ProblemDetail(String type, String title, int status, String detail) {
+        this.type = BASE_TYPE_URI + type;
+        this.title = title;
+        this.status = status;
+        this.detail = detail;
+    }
+    
+    public ProblemDetail(String type, String title, int status, String detail, String instance) {
+        this(type, title, status, detail);
+        this.instance = instance;
+    }
+    
+    public static ProblemDetail invalidArgument(String detail) {
+        return new ProblemDetail("invalid-argument", "Invalid Argument", 400, detail);
+    }
+    
+    public static ProblemDetail invalidArgument(String detail, String instance) {
+        return new ProblemDetail("invalid-argument", "Invalid Argument", 400, detail, instance);
+    }
+    
+    public static ProblemDetail unauthorized(String detail) {
+        return new ProblemDetail("unauthorized", "Unauthorized", 401, detail);
+    }
+    
+    public static ProblemDetail unauthorized(String detail, String instance) {
+        return new ProblemDetail("unauthorized", "Unauthorized", 401, detail, instance);
+    }
+    
+    public static ProblemDetail permissionDenied(String detail) {
+        return new ProblemDetail("permission-denied", "Permission Denied", 403, detail);
+    }
+    
+    public static ProblemDetail permissionDenied(String detail, String instance) {
+        return new ProblemDetail("permission-denied", "Permission Denied", 403, detail, instance);
+    }
+    
+    public static ProblemDetail objectNotFound(String objectId, String repositoryId) {
+        String detail = String.format("The object with ID '%s' was not found in repository '%s'", objectId, repositoryId);
+        return new ProblemDetail("object-not-found", "Object Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail objectNotFound(String objectId, String repositoryId, String instance) {
+        String detail = String.format("The object with ID '%s' was not found in repository '%s'", objectId, repositoryId);
+        return new ProblemDetail("object-not-found", "Object Not Found", 404, detail, instance);
+    }
+    
+    public static ProblemDetail typeNotFound(String typeId, String repositoryId) {
+        String detail = String.format("The type with ID '%s' was not found in repository '%s'", typeId, repositoryId);
+        return new ProblemDetail("type-not-found", "Type Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail repositoryNotFound(String repositoryId) {
+        String detail = String.format("The repository '%s' was not found", repositoryId);
+        return new ProblemDetail("repository-not-found", "Repository Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail userNotFound(String userId, String repositoryId) {
+        String detail = String.format("The user with ID '%s' was not found in repository '%s'", userId, repositoryId);
+        return new ProblemDetail("user-not-found", "User Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail groupNotFound(String groupId, String repositoryId) {
+        String detail = String.format("The group with ID '%s' was not found in repository '%s'", groupId, repositoryId);
+        return new ProblemDetail("group-not-found", "Group Not Found", 404, detail);
+    }
+    
+    public static ProblemDetail conflict(String detail) {
+        return new ProblemDetail("conflict", "Conflict", 409, detail);
+    }
+    
+    public static ProblemDetail conflict(String detail, String instance) {
+        return new ProblemDetail("conflict", "Conflict", 409, detail, instance);
+    }
+    
+    public static ProblemDetail contentAlreadyExists(String objectId) {
+        String detail = String.format("Content already exists for object '%s'", objectId);
+        return new ProblemDetail("content-already-exists", "Content Already Exists", 409, detail);
+    }
+    
+    public static ProblemDetail versionConflict(String objectId, String expectedToken, String actualToken) {
+        String detail = String.format("Version conflict for object '%s': expected changeToken '%s' but found '%s'", 
+                objectId, expectedToken, actualToken);
+        return new ProblemDetail("version-conflict", "Version Conflict", 409, detail);
+    }
+    
+    public static ProblemDetail constraintViolation(String detail) {
+        return new ProblemDetail("constraint-violation", "Constraint Violation", 422, detail);
+    }
+    
+    public static ProblemDetail constraintViolation(String detail, String instance) {
+        return new ProblemDetail("constraint-violation", "Constraint Violation", 422, detail, instance);
+    }
+    
+    public static ProblemDetail internalError(String detail) {
+        return new ProblemDetail("internal-error", "Internal Server Error", 500, detail);
+    }
+    
+    public static ProblemDetail internalError(String detail, String instance) {
+        return new ProblemDetail("internal-error", "Internal Server Error", 500, detail, instance);
+    }
+    
+    public static ProblemDetail serviceUnavailable(String detail) {
+        return new ProblemDetail("service-unavailable", "Service Unavailable", 503, detail);
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public int getStatus() {
+        return status;
+    }
+    
+    public void setStatus(int status) {
+        this.status = status;
+    }
+    
+    public String getDetail() {
+        return detail;
+    }
+    
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+    
+    public String getInstance() {
+        return instance;
+    }
+    
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+    
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+    
+    public void setExtensions(Map<String, Object> extensions) {
+        this.extensions = extensions;
+    }
+    
+    public ProblemDetail withExtension(String key, Object value) {
+        if (this.extensions == null) {
+            this.extensions = new java.util.HashMap<>();
+        }
+        this.extensions.put(key, value);
+        return this;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ValidationExceptionMapper.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/exception/ValidationExceptionMapper.java
@@ -1,0 +1,49 @@
+package jp.aegif.nemaki.api.v1.exception;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Provider
+public class ValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+    
+    private static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+    
+    @Override
+    public Response toResponse(ConstraintViolationException exception) {
+        List<Map<String, String>> violations = exception.getConstraintViolations().stream()
+                .map(this::mapViolation)
+                .collect(Collectors.toList());
+        
+        String detail = violations.stream()
+                .map(v -> v.get("field") + ": " + v.get("message"))
+                .collect(Collectors.joining("; "));
+        
+        ProblemDetail problemDetail = ProblemDetail.invalidArgument(detail);
+        problemDetail.withExtension("violations", violations);
+        
+        return Response.status(400)
+                .type(PROBLEM_JSON_MEDIA_TYPE)
+                .entity(problemDetail)
+                .build();
+    }
+    
+    private Map<String, String> mapViolation(ConstraintViolation<?> violation) {
+        String propertyPath = violation.getPropertyPath().toString();
+        String field = propertyPath.contains(".") 
+                ? propertyPath.substring(propertyPath.lastIndexOf('.') + 1)
+                : propertyPath;
+        
+        return Map.of(
+                "field", field,
+                "message", violation.getMessage(),
+                "invalidValue", String.valueOf(violation.getInvalidValue())
+        );
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiAuthenticationFilter.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.filter;
+
+import jakarta.annotation.Priority;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.logging.Logger;
+
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class ApiAuthenticationFilter implements ContainerRequestFilter {
+    
+    private static final Logger logger = Logger.getLogger(ApiAuthenticationFilter.class.getName());
+    private static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+    
+    @Context
+    private HttpServletRequest httpServletRequest;
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String path = requestContext.getUriInfo().getPath();
+        
+        // Allow access to OpenAPI spec without authentication
+        if (path.endsWith("/openapi.json") || path.endsWith("/openapi.yaml")) {
+            return;
+        }
+        
+        // Allow access to auth endpoints without authentication
+        if (path.contains("/auth/login") || path.contains("/auth/saml") || path.contains("/auth/oidc")) {
+            return;
+        }
+        
+        // Check if CallContext is already set by the existing authentication filter
+        Object callContext = httpServletRequest.getAttribute("CallContext");
+        if (callContext != null) {
+            // Already authenticated by existing filter chain
+            return;
+        }
+        
+        // Check for Authorization header
+        String authHeader = requestContext.getHeaderString("Authorization");
+        if (authHeader == null || authHeader.isEmpty()) {
+            abortWithUnauthorized(requestContext, "Authentication required. Please provide credentials.");
+            return;
+        }
+        
+        // The actual authentication is handled by the existing AuthenticationFilter
+        // This filter just ensures the request has proper authentication headers
+        // and provides RFC 7807 compliant error responses
+        
+        if (authHeader.startsWith("Basic ")) {
+            // Basic auth - validate format
+            try {
+                String credentials = authHeader.substring(6);
+                byte[] decoded = Base64.getDecoder().decode(credentials);
+                String decodedStr = new String(decoded);
+                if (!decodedStr.contains(":")) {
+                    abortWithUnauthorized(requestContext, "Invalid Basic authentication format");
+                    return;
+                }
+            } catch (IllegalArgumentException e) {
+                abortWithUnauthorized(requestContext, "Invalid Basic authentication encoding");
+                return;
+            }
+        } else if (authHeader.startsWith("Bearer ")) {
+            // Bearer token - validate format
+            String token = authHeader.substring(7);
+            if (token.isEmpty()) {
+                abortWithUnauthorized(requestContext, "Empty Bearer token");
+                return;
+            }
+        } else {
+            abortWithUnauthorized(requestContext, "Unsupported authentication scheme. Use Basic or Bearer.");
+            return;
+        }
+        
+        // Authentication will be completed by the existing filter chain
+    }
+    
+    private void abortWithUnauthorized(ContainerRequestContext requestContext, String message) {
+        ProblemDetail problemDetail = ProblemDetail.unauthorized(message, requestContext.getUriInfo().getPath());
+        
+        requestContext.abortWith(
+                Response.status(Response.Status.UNAUTHORIZED)
+                        .header("WWW-Authenticate", "Basic realm=\"NemakiWare\", Bearer realm=\"NemakiWare\"")
+                        .type(PROBLEM_JSON_MEDIA_TYPE)
+                        .entity(problemDetail)
+                        .build()
+        );
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiCorsFilter.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/filter/ApiCorsFilter.java
@@ -1,0 +1,52 @@
+package jp.aegif.nemaki.api.v1.filter;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import java.io.IOException;
+
+@Provider
+@PreMatching
+@Priority(Priorities.HEADER_DECORATOR)
+public class ApiCorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        // Handle preflight requests
+        if (requestContext.getMethod().equalsIgnoreCase("OPTIONS")) {
+            requestContext.abortWith(
+                    Response.ok()
+                            .header("Access-Control-Allow-Origin", "*")
+                            .header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+                            .header("Access-Control-Allow-Headers", 
+                                    "Origin, Content-Type, Accept, Authorization, X-Requested-With, " +
+                                    "X-Change-Token, X-Overwrite-Flag, Content-Disposition")
+                            .header("Access-Control-Max-Age", "86400")
+                            .header("Access-Control-Expose-Headers", 
+                                    "Content-Disposition, X-Total-Count, X-Accessible-Count, " +
+                                    "ETag, Location, Link, Deprecation, Sunset")
+                            .build()
+            );
+        }
+    }
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        // Add CORS headers to all responses
+        responseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
+        responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+        responseContext.getHeaders().add("Access-Control-Allow-Headers", 
+                "Origin, Content-Type, Accept, Authorization, X-Requested-With, " +
+                "X-Change-Token, X-Overwrite-Flag, Content-Disposition");
+        responseContext.getHeaders().add("Access-Control-Expose-Headers", 
+                "Content-Disposition, X-Total-Count, X-Accessible-Count, " +
+                "ETag, Location, Link, Deprecation, Sunset");
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/PropertyValue.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/PropertyValue.java
@@ -1,0 +1,236 @@
+package jp.aegif.nemaki.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Property value with type information for dynamic CMIS properties")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PropertyValue {
+    
+    @Schema(description = "Property value. Can be string, number, boolean, or array for multi-valued properties",
+            example = "invoice-2026-001.pdf")
+    @JsonProperty("value")
+    private Object value;
+    
+    @Schema(description = "Property type identifier",
+            allowableValues = {"string", "boolean", "integer", "decimal", "datetime", "uri", "id", "html"},
+            example = "string")
+    @JsonProperty("type")
+    private String type;
+    
+    @Schema(description = "Human-readable display name for the property",
+            example = "Name")
+    @JsonProperty("displayName")
+    private String displayName;
+    
+    @Schema(description = "Cardinality of the property",
+            allowableValues = {"single", "multi"},
+            example = "single")
+    @JsonProperty("cardinality")
+    private String cardinality;
+    
+    @Schema(description = "Property definition ID",
+            example = "cmis:name")
+    @JsonProperty("propertyDefinitionId")
+    private String propertyDefinitionId;
+    
+    @Schema(description = "Local name of the property",
+            example = "name")
+    @JsonProperty("localName")
+    private String localName;
+    
+    @Schema(description = "Query name for use in CMIS queries",
+            example = "cmis:name")
+    @JsonProperty("queryName")
+    private String queryName;
+    
+    public PropertyValue() {
+    }
+    
+    public PropertyValue(Object value, String type) {
+        this.value = value;
+        this.type = type;
+        this.cardinality = (value instanceof List) ? "multi" : "single";
+    }
+    
+    public PropertyValue(Object value, String type, String displayName) {
+        this(value, type);
+        this.displayName = displayName;
+    }
+    
+    public static PropertyValue ofString(String value) {
+        return new PropertyValue(value, "string");
+    }
+    
+    public static PropertyValue ofString(String value, String displayName) {
+        return new PropertyValue(value, "string", displayName);
+    }
+    
+    public static PropertyValue ofBoolean(Boolean value) {
+        return new PropertyValue(value, "boolean");
+    }
+    
+    public static PropertyValue ofBoolean(Boolean value, String displayName) {
+        return new PropertyValue(value, "boolean", displayName);
+    }
+    
+    public static PropertyValue ofInteger(Long value) {
+        return new PropertyValue(value, "integer");
+    }
+    
+    public static PropertyValue ofInteger(Long value, String displayName) {
+        return new PropertyValue(value, "integer", displayName);
+    }
+    
+    public static PropertyValue ofDecimal(Double value) {
+        return new PropertyValue(value, "decimal");
+    }
+    
+    public static PropertyValue ofDecimal(Double value, String displayName) {
+        return new PropertyValue(value, "decimal", displayName);
+    }
+    
+    public static PropertyValue ofDatetime(String isoDateTime) {
+        return new PropertyValue(isoDateTime, "datetime");
+    }
+    
+    public static PropertyValue ofDatetime(String isoDateTime, String displayName) {
+        return new PropertyValue(isoDateTime, "datetime", displayName);
+    }
+    
+    public static PropertyValue ofId(String id) {
+        return new PropertyValue(id, "id");
+    }
+    
+    public static PropertyValue ofId(String id, String displayName) {
+        return new PropertyValue(id, "id", displayName);
+    }
+    
+    public static PropertyValue ofUri(String uri) {
+        return new PropertyValue(uri, "uri");
+    }
+    
+    public static PropertyValue ofUri(String uri, String displayName) {
+        return new PropertyValue(uri, "uri", displayName);
+    }
+    
+    public static PropertyValue ofHtml(String html) {
+        return new PropertyValue(html, "html");
+    }
+    
+    public static PropertyValue ofHtml(String html, String displayName) {
+        return new PropertyValue(html, "html", displayName);
+    }
+    
+    public static PropertyValue ofMultiString(List<String> values) {
+        PropertyValue pv = new PropertyValue(values, "string");
+        pv.setCardinality("multi");
+        return pv;
+    }
+    
+    public static PropertyValue ofMultiString(List<String> values, String displayName) {
+        PropertyValue pv = new PropertyValue(values, "string", displayName);
+        pv.setCardinality("multi");
+        return pv;
+    }
+    
+    public Object getValue() {
+        return value;
+    }
+    
+    public void setValue(Object value) {
+        this.value = value;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+    
+    public String getCardinality() {
+        return cardinality;
+    }
+    
+    public void setCardinality(String cardinality) {
+        this.cardinality = cardinality;
+    }
+    
+    public String getPropertyDefinitionId() {
+        return propertyDefinitionId;
+    }
+    
+    public void setPropertyDefinitionId(String propertyDefinitionId) {
+        this.propertyDefinitionId = propertyDefinitionId;
+    }
+    
+    public String getLocalName() {
+        return localName;
+    }
+    
+    public void setLocalName(String localName) {
+        this.localName = localName;
+    }
+    
+    public String getQueryName() {
+        return queryName;
+    }
+    
+    public void setQueryName(String queryName) {
+        this.queryName = queryName;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public String getStringValue() {
+        if (value == null) return null;
+        if (value instanceof String) return (String) value;
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            return list.isEmpty() ? null : String.valueOf(list.get(0));
+        }
+        return String.valueOf(value);
+    }
+    
+    public Long getIntegerValue() {
+        if (value == null) return null;
+        if (value instanceof Long) return (Long) value;
+        if (value instanceof Number) return ((Number) value).longValue();
+        if (value instanceof String) return Long.parseLong((String) value);
+        return null;
+    }
+    
+    public Double getDecimalValue() {
+        if (value == null) return null;
+        if (value instanceof Double) return (Double) value;
+        if (value instanceof Number) return ((Number) value).doubleValue();
+        if (value instanceof String) return Double.parseDouble((String) value);
+        return null;
+    }
+    
+    public Boolean getBooleanValue() {
+        if (value == null) return null;
+        if (value instanceof Boolean) return (Boolean) value;
+        if (value instanceof String) return Boolean.parseBoolean((String) value);
+        return null;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public List<String> getMultiStringValue() {
+        if (value == null) return null;
+        if (value instanceof List) return (List<String>) value;
+        return List.of(String.valueOf(value));
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/AclRequest.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/AclRequest.java
@@ -1,0 +1,57 @@
+package jp.aegif.nemaki.api.v1.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "ACL apply request")
+public class AclRequest {
+    
+    @Schema(description = "List of ACE entries to apply", required = true)
+    private List<AceEntry> aces;
+    
+    @Schema(description = "ACL propagation mode (REPOSITORYDETERMINED, OBJECTONLY, PROPAGATE)")
+    private String aclPropagation;
+    
+    public List<AceEntry> getAces() {
+        return aces;
+    }
+    
+    public void setAces(List<AceEntry> aces) {
+        this.aces = aces;
+    }
+    
+    public String getAclPropagation() {
+        return aclPropagation;
+    }
+    
+    public void setAclPropagation(String aclPropagation) {
+        this.aclPropagation = aclPropagation;
+    }
+    
+    @Schema(description = "Access Control Entry")
+    public static class AceEntry {
+        
+        @Schema(description = "Principal ID (user or group)", required = true)
+        private String principalId;
+        
+        @Schema(description = "List of permissions", required = true)
+        private List<String> permissions;
+        
+        public String getPrincipalId() {
+            return principalId;
+        }
+        
+        public void setPrincipalId(String principalId) {
+            this.principalId = principalId;
+        }
+        
+        public List<String> getPermissions() {
+            return permissions;
+        }
+        
+        public void setPermissions(List<String> permissions) {
+            this.permissions = permissions;
+        }
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/PolicyApplyRequest.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/PolicyApplyRequest.java
@@ -1,0 +1,29 @@
+package jp.aegif.nemaki.api.v1.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Policy apply/remove request")
+public class PolicyApplyRequest {
+    
+    @Schema(description = "Policy ID to apply/remove", required = true)
+    private String policyId;
+    
+    @Schema(description = "Object ID to apply/remove policy to/from", required = true)
+    private String objectId;
+    
+    public String getPolicyId() {
+        return policyId;
+    }
+    
+    public void setPolicyId(String policyId) {
+        this.policyId = policyId;
+    }
+    
+    public String getObjectId() {
+        return objectId;
+    }
+    
+    public void setObjectId(String objectId) {
+        this.objectId = objectId;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/PolicyCreateRequest.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/PolicyCreateRequest.java
@@ -1,0 +1,76 @@
+package jp.aegif.nemaki.api.v1.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+
+import java.util.Map;
+
+@Schema(description = "Policy creation request")
+public class PolicyCreateRequest {
+    
+    @Schema(description = "Policy type ID (defaults to cmis:policy)")
+    private String typeId;
+    
+    @Schema(description = "Policy name", required = true)
+    private String name;
+    
+    @Schema(description = "Policy description")
+    private String description;
+    
+    @Schema(description = "Policy text (implementation-specific)")
+    private String policyText;
+    
+    @Schema(description = "Folder ID to file the policy in")
+    private String folderId;
+    
+    @Schema(description = "Additional properties")
+    private Map<String, PropertyValue> properties;
+    
+    public String getTypeId() {
+        return typeId;
+    }
+    
+    public void setTypeId(String typeId) {
+        this.typeId = typeId;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getPolicyText() {
+        return policyText;
+    }
+    
+    public void setPolicyText(String policyText) {
+        this.policyText = policyText;
+    }
+    
+    public String getFolderId() {
+        return folderId;
+    }
+    
+    public void setFolderId(String folderId) {
+        this.folderId = folderId;
+    }
+    
+    public Map<String, PropertyValue> getProperties() {
+        return properties;
+    }
+    
+    public void setProperties(Map<String, PropertyValue> properties) {
+        this.properties = properties;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/RelationshipRequest.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/request/RelationshipRequest.java
@@ -1,0 +1,65 @@
+package jp.aegif.nemaki.api.v1.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+
+import java.util.Map;
+
+@Schema(description = "Relationship creation request")
+public class RelationshipRequest {
+    
+    @Schema(description = "Relationship type ID (defaults to cmis:relationship)")
+    private String typeId;
+    
+    @Schema(description = "Source object ID", required = true)
+    private String sourceId;
+    
+    @Schema(description = "Target object ID", required = true)
+    private String targetId;
+    
+    @Schema(description = "Relationship name")
+    private String name;
+    
+    @Schema(description = "Additional properties")
+    private Map<String, PropertyValue> properties;
+    
+    public String getTypeId() {
+        return typeId;
+    }
+    
+    public void setTypeId(String typeId) {
+        this.typeId = typeId;
+    }
+    
+    public String getSourceId() {
+        return sourceId;
+    }
+    
+    public void setSourceId(String sourceId) {
+        this.sourceId = sourceId;
+    }
+    
+    public String getTargetId() {
+        return targetId;
+    }
+    
+    public void setTargetId(String targetId) {
+        this.targetId = targetId;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public Map<String, PropertyValue> getProperties() {
+        return properties;
+    }
+    
+    public void setProperties(Map<String, PropertyValue> properties) {
+        this.properties = properties;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AclCapabilities.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AclCapabilities.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "ACL capabilities")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AclCapabilities {
+    
+    @Schema(description = "Supported permissions", example = "basic")
+    @JsonProperty("supportedPermissions")
+    private String supportedPermissions;
+    
+    @Schema(description = "ACL propagation", example = "propagate")
+    @JsonProperty("aclPropagation")
+    private String aclPropagation;
+    
+    @Schema(description = "List of permissions")
+    @JsonProperty("permissions")
+    private List<PermissionDefinition> permissions;
+    
+    @Schema(description = "Permission mapping")
+    @JsonProperty("permissionMapping")
+    private Map<String, List<String>> permissionMapping;
+    
+    public AclCapabilities() {
+    }
+    
+    public String getSupportedPermissions() {
+        return supportedPermissions;
+    }
+    
+    public void setSupportedPermissions(String supportedPermissions) {
+        this.supportedPermissions = supportedPermissions;
+    }
+    
+    public String getAclPropagation() {
+        return aclPropagation;
+    }
+    
+    public void setAclPropagation(String aclPropagation) {
+        this.aclPropagation = aclPropagation;
+    }
+    
+    public List<PermissionDefinition> getPermissions() {
+        return permissions;
+    }
+    
+    public void setPermissions(List<PermissionDefinition> permissions) {
+        this.permissions = permissions;
+    }
+    
+    public Map<String, List<String>> getPermissionMapping() {
+        return permissionMapping;
+    }
+    
+    public void setPermissionMapping(Map<String, List<String>> permissionMapping) {
+        this.permissionMapping = permissionMapping;
+    }
+    
+    @Schema(description = "Permission definition")
+    public static class PermissionDefinition {
+        
+        @Schema(description = "Permission ID", example = "cmis:read")
+        @JsonProperty("permission")
+        private String permission;
+        
+        @Schema(description = "Permission description", example = "Read permission")
+        @JsonProperty("description")
+        private String description;
+        
+        public PermissionDefinition() {
+        }
+        
+        public PermissionDefinition(String permission, String description) {
+            this.permission = permission;
+            this.description = description;
+        }
+        
+        public String getPermission() {
+            return permission;
+        }
+        
+        public void setPermission(String permission) {
+            this.permission = permission;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+        
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AclResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AclResponse.java
@@ -1,0 +1,91 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "ACL response")
+public class AclResponse {
+    
+    @Schema(description = "Object ID")
+    private String objectId;
+    
+    @Schema(description = "Whether the ACL is exact (not inherited)")
+    private Boolean exact;
+    
+    @Schema(description = "List of ACE entries")
+    private List<AceEntry> aces;
+    
+    @Schema(description = "HATEOAS links")
+    private Map<String, LinkInfo> links;
+    
+    public String getObjectId() {
+        return objectId;
+    }
+    
+    public void setObjectId(String objectId) {
+        this.objectId = objectId;
+    }
+    
+    public Boolean getExact() {
+        return exact;
+    }
+    
+    public void setExact(Boolean exact) {
+        this.exact = exact;
+    }
+    
+    public List<AceEntry> getAces() {
+        return aces;
+    }
+    
+    public void setAces(List<AceEntry> aces) {
+        this.aces = aces;
+    }
+    
+    public Map<String, LinkInfo> getLinks() {
+        return links;
+    }
+    
+    public void setLinks(Map<String, LinkInfo> links) {
+        this.links = links;
+    }
+    
+    @Schema(description = "Access Control Entry")
+    public static class AceEntry {
+        
+        @Schema(description = "Principal ID (user or group)")
+        private String principalId;
+        
+        @Schema(description = "List of permissions")
+        private List<String> permissions;
+        
+        @Schema(description = "Whether this ACE is directly applied (not inherited)")
+        private Boolean direct;
+        
+        public String getPrincipalId() {
+            return principalId;
+        }
+        
+        public void setPrincipalId(String principalId) {
+            this.principalId = principalId;
+        }
+        
+        public List<String> getPermissions() {
+            return permissions;
+        }
+        
+        public void setPermissions(List<String> permissions) {
+            this.permissions = permissions;
+        }
+        
+        public Boolean getDirect() {
+            return direct;
+        }
+        
+        public void setDirect(Boolean direct) {
+            this.direct = direct;
+        }
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AllowableActionsResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/AllowableActionsResponse.java
@@ -1,0 +1,343 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "CMIS allowable actions for an object")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AllowableActionsResponse {
+    
+    @JsonProperty("canDeleteObject")
+    private Boolean canDeleteObject;
+    
+    @JsonProperty("canUpdateProperties")
+    private Boolean canUpdateProperties;
+    
+    @JsonProperty("canGetFolderTree")
+    private Boolean canGetFolderTree;
+    
+    @JsonProperty("canGetProperties")
+    private Boolean canGetProperties;
+    
+    @JsonProperty("canGetObjectRelationships")
+    private Boolean canGetObjectRelationships;
+    
+    @JsonProperty("canGetObjectParents")
+    private Boolean canGetObjectParents;
+    
+    @JsonProperty("canGetFolderParent")
+    private Boolean canGetFolderParent;
+    
+    @JsonProperty("canGetDescendants")
+    private Boolean canGetDescendants;
+    
+    @JsonProperty("canMoveObject")
+    private Boolean canMoveObject;
+    
+    @JsonProperty("canDeleteContentStream")
+    private Boolean canDeleteContentStream;
+    
+    @JsonProperty("canCheckOut")
+    private Boolean canCheckOut;
+    
+    @JsonProperty("canCancelCheckOut")
+    private Boolean canCancelCheckOut;
+    
+    @JsonProperty("canCheckIn")
+    private Boolean canCheckIn;
+    
+    @JsonProperty("canSetContentStream")
+    private Boolean canSetContentStream;
+    
+    @JsonProperty("canGetAllVersions")
+    private Boolean canGetAllVersions;
+    
+    @JsonProperty("canAddObjectToFolder")
+    private Boolean canAddObjectToFolder;
+    
+    @JsonProperty("canRemoveObjectFromFolder")
+    private Boolean canRemoveObjectFromFolder;
+    
+    @JsonProperty("canGetContentStream")
+    private Boolean canGetContentStream;
+    
+    @JsonProperty("canApplyPolicy")
+    private Boolean canApplyPolicy;
+    
+    @JsonProperty("canGetAppliedPolicies")
+    private Boolean canGetAppliedPolicies;
+    
+    @JsonProperty("canRemovePolicy")
+    private Boolean canRemovePolicy;
+    
+    @JsonProperty("canGetChildren")
+    private Boolean canGetChildren;
+    
+    @JsonProperty("canCreateDocument")
+    private Boolean canCreateDocument;
+    
+    @JsonProperty("canCreateFolder")
+    private Boolean canCreateFolder;
+    
+    @JsonProperty("canCreateRelationship")
+    private Boolean canCreateRelationship;
+    
+    @JsonProperty("canCreateItem")
+    private Boolean canCreateItem;
+    
+    @JsonProperty("canDeleteTree")
+    private Boolean canDeleteTree;
+    
+    @JsonProperty("canGetRenditions")
+    private Boolean canGetRenditions;
+    
+    @JsonProperty("canGetAcl")
+    private Boolean canGetAcl;
+    
+    @JsonProperty("canApplyAcl")
+    private Boolean canApplyAcl;
+    
+    public AllowableActionsResponse() {
+    }
+    
+    public Boolean getCanDeleteObject() {
+        return canDeleteObject;
+    }
+    
+    public void setCanDeleteObject(Boolean canDeleteObject) {
+        this.canDeleteObject = canDeleteObject;
+    }
+    
+    public Boolean getCanUpdateProperties() {
+        return canUpdateProperties;
+    }
+    
+    public void setCanUpdateProperties(Boolean canUpdateProperties) {
+        this.canUpdateProperties = canUpdateProperties;
+    }
+    
+    public Boolean getCanGetFolderTree() {
+        return canGetFolderTree;
+    }
+    
+    public void setCanGetFolderTree(Boolean canGetFolderTree) {
+        this.canGetFolderTree = canGetFolderTree;
+    }
+    
+    public Boolean getCanGetProperties() {
+        return canGetProperties;
+    }
+    
+    public void setCanGetProperties(Boolean canGetProperties) {
+        this.canGetProperties = canGetProperties;
+    }
+    
+    public Boolean getCanGetObjectRelationships() {
+        return canGetObjectRelationships;
+    }
+    
+    public void setCanGetObjectRelationships(Boolean canGetObjectRelationships) {
+        this.canGetObjectRelationships = canGetObjectRelationships;
+    }
+    
+    public Boolean getCanGetObjectParents() {
+        return canGetObjectParents;
+    }
+    
+    public void setCanGetObjectParents(Boolean canGetObjectParents) {
+        this.canGetObjectParents = canGetObjectParents;
+    }
+    
+    public Boolean getCanGetFolderParent() {
+        return canGetFolderParent;
+    }
+    
+    public void setCanGetFolderParent(Boolean canGetFolderParent) {
+        this.canGetFolderParent = canGetFolderParent;
+    }
+    
+    public Boolean getCanGetDescendants() {
+        return canGetDescendants;
+    }
+    
+    public void setCanGetDescendants(Boolean canGetDescendants) {
+        this.canGetDescendants = canGetDescendants;
+    }
+    
+    public Boolean getCanMoveObject() {
+        return canMoveObject;
+    }
+    
+    public void setCanMoveObject(Boolean canMoveObject) {
+        this.canMoveObject = canMoveObject;
+    }
+    
+    public Boolean getCanDeleteContentStream() {
+        return canDeleteContentStream;
+    }
+    
+    public void setCanDeleteContentStream(Boolean canDeleteContentStream) {
+        this.canDeleteContentStream = canDeleteContentStream;
+    }
+    
+    public Boolean getCanCheckOut() {
+        return canCheckOut;
+    }
+    
+    public void setCanCheckOut(Boolean canCheckOut) {
+        this.canCheckOut = canCheckOut;
+    }
+    
+    public Boolean getCanCancelCheckOut() {
+        return canCancelCheckOut;
+    }
+    
+    public void setCanCancelCheckOut(Boolean canCancelCheckOut) {
+        this.canCancelCheckOut = canCancelCheckOut;
+    }
+    
+    public Boolean getCanCheckIn() {
+        return canCheckIn;
+    }
+    
+    public void setCanCheckIn(Boolean canCheckIn) {
+        this.canCheckIn = canCheckIn;
+    }
+    
+    public Boolean getCanSetContentStream() {
+        return canSetContentStream;
+    }
+    
+    public void setCanSetContentStream(Boolean canSetContentStream) {
+        this.canSetContentStream = canSetContentStream;
+    }
+    
+    public Boolean getCanGetAllVersions() {
+        return canGetAllVersions;
+    }
+    
+    public void setCanGetAllVersions(Boolean canGetAllVersions) {
+        this.canGetAllVersions = canGetAllVersions;
+    }
+    
+    public Boolean getCanAddObjectToFolder() {
+        return canAddObjectToFolder;
+    }
+    
+    public void setCanAddObjectToFolder(Boolean canAddObjectToFolder) {
+        this.canAddObjectToFolder = canAddObjectToFolder;
+    }
+    
+    public Boolean getCanRemoveObjectFromFolder() {
+        return canRemoveObjectFromFolder;
+    }
+    
+    public void setCanRemoveObjectFromFolder(Boolean canRemoveObjectFromFolder) {
+        this.canRemoveObjectFromFolder = canRemoveObjectFromFolder;
+    }
+    
+    public Boolean getCanGetContentStream() {
+        return canGetContentStream;
+    }
+    
+    public void setCanGetContentStream(Boolean canGetContentStream) {
+        this.canGetContentStream = canGetContentStream;
+    }
+    
+    public Boolean getCanApplyPolicy() {
+        return canApplyPolicy;
+    }
+    
+    public void setCanApplyPolicy(Boolean canApplyPolicy) {
+        this.canApplyPolicy = canApplyPolicy;
+    }
+    
+    public Boolean getCanGetAppliedPolicies() {
+        return canGetAppliedPolicies;
+    }
+    
+    public void setCanGetAppliedPolicies(Boolean canGetAppliedPolicies) {
+        this.canGetAppliedPolicies = canGetAppliedPolicies;
+    }
+    
+    public Boolean getCanRemovePolicy() {
+        return canRemovePolicy;
+    }
+    
+    public void setCanRemovePolicy(Boolean canRemovePolicy) {
+        this.canRemovePolicy = canRemovePolicy;
+    }
+    
+    public Boolean getCanGetChildren() {
+        return canGetChildren;
+    }
+    
+    public void setCanGetChildren(Boolean canGetChildren) {
+        this.canGetChildren = canGetChildren;
+    }
+    
+    public Boolean getCanCreateDocument() {
+        return canCreateDocument;
+    }
+    
+    public void setCanCreateDocument(Boolean canCreateDocument) {
+        this.canCreateDocument = canCreateDocument;
+    }
+    
+    public Boolean getCanCreateFolder() {
+        return canCreateFolder;
+    }
+    
+    public void setCanCreateFolder(Boolean canCreateFolder) {
+        this.canCreateFolder = canCreateFolder;
+    }
+    
+    public Boolean getCanCreateRelationship() {
+        return canCreateRelationship;
+    }
+    
+    public void setCanCreateRelationship(Boolean canCreateRelationship) {
+        this.canCreateRelationship = canCreateRelationship;
+    }
+    
+    public Boolean getCanCreateItem() {
+        return canCreateItem;
+    }
+    
+    public void setCanCreateItem(Boolean canCreateItem) {
+        this.canCreateItem = canCreateItem;
+    }
+    
+    public Boolean getCanDeleteTree() {
+        return canDeleteTree;
+    }
+    
+    public void setCanDeleteTree(Boolean canDeleteTree) {
+        this.canDeleteTree = canDeleteTree;
+    }
+    
+    public Boolean getCanGetRenditions() {
+        return canGetRenditions;
+    }
+    
+    public void setCanGetRenditions(Boolean canGetRenditions) {
+        this.canGetRenditions = canGetRenditions;
+    }
+    
+    public Boolean getCanGetAcl() {
+        return canGetAcl;
+    }
+    
+    public void setCanGetAcl(Boolean canGetAcl) {
+        this.canGetAcl = canGetAcl;
+    }
+    
+    public Boolean getCanApplyAcl() {
+        return canApplyAcl;
+    }
+    
+    public void setCanApplyAcl(Boolean canApplyAcl) {
+        this.canApplyAcl = canApplyAcl;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/LinkInfo.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/LinkInfo.java
@@ -1,0 +1,100 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "HATEOAS link information")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LinkInfo {
+    
+    @Schema(description = "Link URL", example = "/api/v1/repositories/bedroom/objects/OBJECT_ID")
+    @JsonProperty("href")
+    private String href;
+    
+    @Schema(description = "HTTP method for the link", example = "GET")
+    @JsonProperty("method")
+    private String method;
+    
+    @Schema(description = "Link title/description", example = "Get object details")
+    @JsonProperty("title")
+    private String title;
+    
+    @Schema(description = "Media type of the linked resource", example = "application/json")
+    @JsonProperty("type")
+    private String type;
+    
+    public LinkInfo() {
+    }
+    
+    public LinkInfo(String href) {
+        this.href = href;
+    }
+    
+    public LinkInfo(String href, String method) {
+        this.href = href;
+        this.method = method;
+    }
+    
+    public static LinkInfo of(String href) {
+        return new LinkInfo(href);
+    }
+    
+    public static LinkInfo get(String href) {
+        return new LinkInfo(href, "GET");
+    }
+    
+    public static LinkInfo post(String href) {
+        return new LinkInfo(href, "POST");
+    }
+    
+    public static LinkInfo put(String href) {
+        return new LinkInfo(href, "PUT");
+    }
+    
+    public static LinkInfo delete(String href) {
+        return new LinkInfo(href, "DELETE");
+    }
+    
+    public String getHref() {
+        return href;
+    }
+    
+    public void setHref(String href) {
+        this.href = href;
+    }
+    
+    public String getMethod() {
+        return method;
+    }
+    
+    public void setMethod(String method) {
+        this.method = method;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public LinkInfo withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+    
+    public LinkInfo withType(String type) {
+        this.type = type;
+        return this;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/ObjectListResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/ObjectListResponse.java
@@ -1,0 +1,88 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Paginated list of CMIS objects")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ObjectListResponse {
+    
+    @Schema(description = "List of objects")
+    @JsonProperty("objects")
+    private List<ObjectResponse> objects;
+    
+    @Schema(description = "Total number of items available", example = "150")
+    @JsonProperty("numItems")
+    private Long numItems;
+    
+    @Schema(description = "Whether there are more items available", example = "true")
+    @JsonProperty("hasMoreItems")
+    private Boolean hasMoreItems;
+    
+    @Schema(description = "Number of items skipped", example = "0")
+    @JsonProperty("skipCount")
+    private Long skipCount;
+    
+    @Schema(description = "Maximum number of items returned", example = "100")
+    @JsonProperty("maxItems")
+    private Long maxItems;
+    
+    @Schema(description = "HATEOAS links for pagination")
+    @JsonProperty("_links")
+    private Map<String, LinkInfo> links;
+    
+    public ObjectListResponse() {
+    }
+    
+    public List<ObjectResponse> getObjects() {
+        return objects;
+    }
+    
+    public void setObjects(List<ObjectResponse> objects) {
+        this.objects = objects;
+    }
+    
+    public Long getNumItems() {
+        return numItems;
+    }
+    
+    public void setNumItems(Long numItems) {
+        this.numItems = numItems;
+    }
+    
+    public Boolean getHasMoreItems() {
+        return hasMoreItems;
+    }
+    
+    public void setHasMoreItems(Boolean hasMoreItems) {
+        this.hasMoreItems = hasMoreItems;
+    }
+    
+    public Long getSkipCount() {
+        return skipCount;
+    }
+    
+    public void setSkipCount(Long skipCount) {
+        this.skipCount = skipCount;
+    }
+    
+    public Long getMaxItems() {
+        return maxItems;
+    }
+    
+    public void setMaxItems(Long maxItems) {
+        this.maxItems = maxItems;
+    }
+    
+    public Map<String, LinkInfo> getLinks() {
+        return links;
+    }
+    
+    public void setLinks(Map<String, LinkInfo> links) {
+        this.links = links;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/ObjectResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/ObjectResponse.java
@@ -1,0 +1,377 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "CMIS object response with properties and metadata")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ObjectResponse {
+    
+    @Schema(description = "Object ID", example = "obj-12345")
+    @JsonProperty("objectId")
+    private String objectId;
+    
+    @Schema(description = "Base type ID", example = "cmis:document")
+    @JsonProperty("baseTypeId")
+    private String baseTypeId;
+    
+    @Schema(description = "Object type ID", example = "cmis:document")
+    @JsonProperty("objectTypeId")
+    private String objectTypeId;
+    
+    @Schema(description = "Object name", example = "invoice-2026-001.pdf")
+    @JsonProperty("name")
+    private String name;
+    
+    @Schema(description = "Object description")
+    @JsonProperty("description")
+    private String description;
+    
+    @Schema(description = "Creator username", example = "admin")
+    @JsonProperty("createdBy")
+    private String createdBy;
+    
+    @Schema(description = "Creation date in ISO 8601 format", example = "2026-01-19T09:00:00Z")
+    @JsonProperty("creationDate")
+    private String creationDate;
+    
+    @Schema(description = "Last modifier username", example = "admin")
+    @JsonProperty("lastModifiedBy")
+    private String lastModifiedBy;
+    
+    @Schema(description = "Last modification date in ISO 8601 format", example = "2026-01-19T10:30:00Z")
+    @JsonProperty("lastModificationDate")
+    private String lastModificationDate;
+    
+    @Schema(description = "Change token for optimistic locking")
+    @JsonProperty("changeToken")
+    private String changeToken;
+    
+    @Schema(description = "Parent folder ID (for fileable objects)")
+    @JsonProperty("parentId")
+    private String parentId;
+    
+    @Schema(description = "Object path (for fileable objects)", example = "/invoices/2026/invoice-001.pdf")
+    @JsonProperty("path")
+    private String path;
+    
+    @Schema(description = "Whether this is the latest version")
+    @JsonProperty("isLatestVersion")
+    private Boolean isLatestVersion;
+    
+    @Schema(description = "Whether this is the latest major version")
+    @JsonProperty("isLatestMajorVersion")
+    private Boolean isLatestMajorVersion;
+    
+    @Schema(description = "Whether this is a major version")
+    @JsonProperty("isMajorVersion")
+    private Boolean isMajorVersion;
+    
+    @Schema(description = "Version label", example = "1.0")
+    @JsonProperty("versionLabel")
+    private String versionLabel;
+    
+    @Schema(description = "Version series ID")
+    @JsonProperty("versionSeriesId")
+    private String versionSeriesId;
+    
+    @Schema(description = "Whether the version series is checked out")
+    @JsonProperty("isVersionSeriesCheckedOut")
+    private Boolean isVersionSeriesCheckedOut;
+    
+    @Schema(description = "User who checked out the version series")
+    @JsonProperty("versionSeriesCheckedOutBy")
+    private String versionSeriesCheckedOutBy;
+    
+    @Schema(description = "ID of the private working copy")
+    @JsonProperty("versionSeriesCheckedOutId")
+    private String versionSeriesCheckedOutId;
+    
+    @Schema(description = "Checkin comment")
+    @JsonProperty("checkinComment")
+    private String checkinComment;
+    
+    @Schema(description = "Content stream length in bytes")
+    @JsonProperty("contentStreamLength")
+    private Long contentStreamLength;
+    
+    @Schema(description = "Content stream MIME type", example = "application/pdf")
+    @JsonProperty("contentStreamMimeType")
+    private String contentStreamMimeType;
+    
+    @Schema(description = "Content stream file name", example = "invoice-001.pdf")
+    @JsonProperty("contentStreamFileName")
+    private String contentStreamFileName;
+    
+    @Schema(description = "Content stream ID")
+    @JsonProperty("contentStreamId")
+    private String contentStreamId;
+    
+    @Schema(description = "Whether this object is immutable")
+    @JsonProperty("isImmutable")
+    private Boolean isImmutable;
+    
+    @Schema(description = "Secondary type IDs")
+    @JsonProperty("secondaryTypeIds")
+    private List<String> secondaryTypeIds;
+    
+    @Schema(description = "Object properties with 2-layer structure (value/type)")
+    @JsonProperty("properties")
+    private Map<String, PropertyValue> properties;
+    
+    @Schema(description = "Allowable actions for this object")
+    @JsonProperty("allowableActions")
+    private AllowableActionsResponse allowableActions;
+    
+    @Schema(description = "HATEOAS links")
+    @JsonProperty("_links")
+    private Map<String, LinkInfo> links;
+    
+    public ObjectResponse() {
+    }
+    
+    public String getObjectId() {
+        return objectId;
+    }
+    
+    public void setObjectId(String objectId) {
+        this.objectId = objectId;
+    }
+    
+    public String getBaseTypeId() {
+        return baseTypeId;
+    }
+    
+    public void setBaseTypeId(String baseTypeId) {
+        this.baseTypeId = baseTypeId;
+    }
+    
+    public String getObjectTypeId() {
+        return objectTypeId;
+    }
+    
+    public void setObjectTypeId(String objectTypeId) {
+        this.objectTypeId = objectTypeId;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getCreatedBy() {
+        return createdBy;
+    }
+    
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+    
+    public String getCreationDate() {
+        return creationDate;
+    }
+    
+    public void setCreationDate(String creationDate) {
+        this.creationDate = creationDate;
+    }
+    
+    public String getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+    
+    public void setLastModifiedBy(String lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+    
+    public String getLastModificationDate() {
+        return lastModificationDate;
+    }
+    
+    public void setLastModificationDate(String lastModificationDate) {
+        this.lastModificationDate = lastModificationDate;
+    }
+    
+    public String getChangeToken() {
+        return changeToken;
+    }
+    
+    public void setChangeToken(String changeToken) {
+        this.changeToken = changeToken;
+    }
+    
+    public String getParentId() {
+        return parentId;
+    }
+    
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+    
+    public String getPath() {
+        return path;
+    }
+    
+    public void setPath(String path) {
+        this.path = path;
+    }
+    
+    public Boolean getIsLatestVersion() {
+        return isLatestVersion;
+    }
+    
+    public void setIsLatestVersion(Boolean isLatestVersion) {
+        this.isLatestVersion = isLatestVersion;
+    }
+    
+    public Boolean getIsLatestMajorVersion() {
+        return isLatestMajorVersion;
+    }
+    
+    public void setIsLatestMajorVersion(Boolean isLatestMajorVersion) {
+        this.isLatestMajorVersion = isLatestMajorVersion;
+    }
+    
+    public Boolean getIsMajorVersion() {
+        return isMajorVersion;
+    }
+    
+    public void setIsMajorVersion(Boolean isMajorVersion) {
+        this.isMajorVersion = isMajorVersion;
+    }
+    
+    public String getVersionLabel() {
+        return versionLabel;
+    }
+    
+    public void setVersionLabel(String versionLabel) {
+        this.versionLabel = versionLabel;
+    }
+    
+    public String getVersionSeriesId() {
+        return versionSeriesId;
+    }
+    
+    public void setVersionSeriesId(String versionSeriesId) {
+        this.versionSeriesId = versionSeriesId;
+    }
+    
+    public Boolean getIsVersionSeriesCheckedOut() {
+        return isVersionSeriesCheckedOut;
+    }
+    
+    public void setIsVersionSeriesCheckedOut(Boolean isVersionSeriesCheckedOut) {
+        this.isVersionSeriesCheckedOut = isVersionSeriesCheckedOut;
+    }
+    
+    public String getVersionSeriesCheckedOutBy() {
+        return versionSeriesCheckedOutBy;
+    }
+    
+    public void setVersionSeriesCheckedOutBy(String versionSeriesCheckedOutBy) {
+        this.versionSeriesCheckedOutBy = versionSeriesCheckedOutBy;
+    }
+    
+    public String getVersionSeriesCheckedOutId() {
+        return versionSeriesCheckedOutId;
+    }
+    
+    public void setVersionSeriesCheckedOutId(String versionSeriesCheckedOutId) {
+        this.versionSeriesCheckedOutId = versionSeriesCheckedOutId;
+    }
+    
+    public String getCheckinComment() {
+        return checkinComment;
+    }
+    
+    public void setCheckinComment(String checkinComment) {
+        this.checkinComment = checkinComment;
+    }
+    
+    public Long getContentStreamLength() {
+        return contentStreamLength;
+    }
+    
+    public void setContentStreamLength(Long contentStreamLength) {
+        this.contentStreamLength = contentStreamLength;
+    }
+    
+    public String getContentStreamMimeType() {
+        return contentStreamMimeType;
+    }
+    
+    public void setContentStreamMimeType(String contentStreamMimeType) {
+        this.contentStreamMimeType = contentStreamMimeType;
+    }
+    
+    public String getContentStreamFileName() {
+        return contentStreamFileName;
+    }
+    
+    public void setContentStreamFileName(String contentStreamFileName) {
+        this.contentStreamFileName = contentStreamFileName;
+    }
+    
+    public String getContentStreamId() {
+        return contentStreamId;
+    }
+    
+    public void setContentStreamId(String contentStreamId) {
+        this.contentStreamId = contentStreamId;
+    }
+    
+    public Boolean getIsImmutable() {
+        return isImmutable;
+    }
+    
+    public void setIsImmutable(Boolean isImmutable) {
+        this.isImmutable = isImmutable;
+    }
+    
+    public List<String> getSecondaryTypeIds() {
+        return secondaryTypeIds;
+    }
+    
+    public void setSecondaryTypeIds(List<String> secondaryTypeIds) {
+        this.secondaryTypeIds = secondaryTypeIds;
+    }
+    
+    public Map<String, PropertyValue> getProperties() {
+        return properties;
+    }
+    
+    public void setProperties(Map<String, PropertyValue> properties) {
+        this.properties = properties;
+    }
+    
+    public AllowableActionsResponse getAllowableActions() {
+        return allowableActions;
+    }
+    
+    public void setAllowableActions(AllowableActionsResponse allowableActions) {
+        this.allowableActions = allowableActions;
+    }
+    
+    public Map<String, LinkInfo> getLinks() {
+        return links;
+    }
+    
+    public void setLinks(Map<String, LinkInfo> links) {
+        this.links = links;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/PolicyListResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/PolicyListResponse.java
@@ -1,0 +1,54 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Applied policies list response")
+public class PolicyListResponse {
+    
+    @Schema(description = "Object ID that policies are applied to")
+    private String objectId;
+    
+    @Schema(description = "List of applied policies")
+    private List<ObjectResponse> policies;
+    
+    @Schema(description = "Number of applied policies")
+    private Integer numPolicies;
+    
+    @Schema(description = "HATEOAS links")
+    private Map<String, LinkInfo> links;
+    
+    public String getObjectId() {
+        return objectId;
+    }
+    
+    public void setObjectId(String objectId) {
+        this.objectId = objectId;
+    }
+    
+    public List<ObjectResponse> getPolicies() {
+        return policies;
+    }
+    
+    public void setPolicies(List<ObjectResponse> policies) {
+        this.policies = policies;
+    }
+    
+    public Integer getNumPolicies() {
+        return numPolicies;
+    }
+    
+    public void setNumPolicies(Integer numPolicies) {
+        this.numPolicies = numPolicies;
+    }
+    
+    public Map<String, LinkInfo> getLinks() {
+        return links;
+    }
+    
+    public void setLinks(Map<String, LinkInfo> links) {
+        this.links = links;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RelationshipResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RelationshipResponse.java
@@ -1,0 +1,131 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+
+import java.util.Map;
+
+@Schema(description = "Relationship response")
+public class RelationshipResponse {
+    
+    @Schema(description = "Object ID")
+    private String objectId;
+    
+    @Schema(description = "Object type ID")
+    private String objectTypeId;
+    
+    @Schema(description = "Relationship name")
+    private String name;
+    
+    @Schema(description = "Source object ID")
+    private String sourceId;
+    
+    @Schema(description = "Target object ID")
+    private String targetId;
+    
+    @Schema(description = "Created by user")
+    private String createdBy;
+    
+    @Schema(description = "Creation date (ISO 8601)")
+    private String creationDate;
+    
+    @Schema(description = "Last modified by user")
+    private String lastModifiedBy;
+    
+    @Schema(description = "Last modification date (ISO 8601)")
+    private String lastModificationDate;
+    
+    @Schema(description = "All properties with type information")
+    private Map<String, PropertyValue> properties;
+    
+    @Schema(description = "HATEOAS links")
+    private Map<String, LinkInfo> links;
+    
+    public String getObjectId() {
+        return objectId;
+    }
+    
+    public void setObjectId(String objectId) {
+        this.objectId = objectId;
+    }
+    
+    public String getObjectTypeId() {
+        return objectTypeId;
+    }
+    
+    public void setObjectTypeId(String objectTypeId) {
+        this.objectTypeId = objectTypeId;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getSourceId() {
+        return sourceId;
+    }
+    
+    public void setSourceId(String sourceId) {
+        this.sourceId = sourceId;
+    }
+    
+    public String getTargetId() {
+        return targetId;
+    }
+    
+    public void setTargetId(String targetId) {
+        this.targetId = targetId;
+    }
+    
+    public String getCreatedBy() {
+        return createdBy;
+    }
+    
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+    
+    public String getCreationDate() {
+        return creationDate;
+    }
+    
+    public void setCreationDate(String creationDate) {
+        this.creationDate = creationDate;
+    }
+    
+    public String getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+    
+    public void setLastModifiedBy(String lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+    
+    public String getLastModificationDate() {
+        return lastModificationDate;
+    }
+    
+    public void setLastModificationDate(String lastModificationDate) {
+        this.lastModificationDate = lastModificationDate;
+    }
+    
+    public Map<String, PropertyValue> getProperties() {
+        return properties;
+    }
+    
+    public void setProperties(Map<String, PropertyValue> properties) {
+        this.properties = properties;
+    }
+    
+    public Map<String, LinkInfo> getLinks() {
+        return links;
+    }
+    
+    public void setLinks(Map<String, LinkInfo> links) {
+        this.links = links;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryCapabilities.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryCapabilities.java
@@ -1,0 +1,193 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Repository capabilities")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RepositoryCapabilities {
+    
+    @Schema(description = "ACL capability", example = "manage")
+    @JsonProperty("capabilityAcl")
+    private String capabilityAcl;
+    
+    @Schema(description = "All versions searchable capability")
+    @JsonProperty("capabilityAllVersionsSearchable")
+    private Boolean capabilityAllVersionsSearchable;
+    
+    @Schema(description = "Changes capability", example = "objectidsonly")
+    @JsonProperty("capabilityChanges")
+    private String capabilityChanges;
+    
+    @Schema(description = "Content stream updates capability", example = "anytime")
+    @JsonProperty("capabilityContentStreamUpdatability")
+    private String capabilityContentStreamUpdatability;
+    
+    @Schema(description = "Get descendants capability")
+    @JsonProperty("capabilityGetDescendants")
+    private Boolean capabilityGetDescendants;
+    
+    @Schema(description = "Get folder tree capability")
+    @JsonProperty("capabilityGetFolderTree")
+    private Boolean capabilityGetFolderTree;
+    
+    @Schema(description = "Order by capability", example = "common")
+    @JsonProperty("capabilityOrderBy")
+    private String capabilityOrderBy;
+    
+    @Schema(description = "Multifiling capability")
+    @JsonProperty("capabilityMultifiling")
+    private Boolean capabilityMultifiling;
+    
+    @Schema(description = "PWC searchable capability")
+    @JsonProperty("capabilityPwcSearchable")
+    private Boolean capabilityPwcSearchable;
+    
+    @Schema(description = "PWC updatable capability")
+    @JsonProperty("capabilityPwcUpdatable")
+    private Boolean capabilityPwcUpdatable;
+    
+    @Schema(description = "Query capability", example = "bothcombined")
+    @JsonProperty("capabilityQuery")
+    private String capabilityQuery;
+    
+    @Schema(description = "Renditions capability", example = "read")
+    @JsonProperty("capabilityRenditions")
+    private String capabilityRenditions;
+    
+    @Schema(description = "Unfiling capability")
+    @JsonProperty("capabilityUnfiling")
+    private Boolean capabilityUnfiling;
+    
+    @Schema(description = "Version specific filing capability")
+    @JsonProperty("capabilityVersionSpecificFiling")
+    private Boolean capabilityVersionSpecificFiling;
+    
+    @Schema(description = "Join capability", example = "none")
+    @JsonProperty("capabilityJoin")
+    private String capabilityJoin;
+    
+    public RepositoryCapabilities() {
+    }
+    
+    public String getCapabilityAcl() {
+        return capabilityAcl;
+    }
+    
+    public void setCapabilityAcl(String capabilityAcl) {
+        this.capabilityAcl = capabilityAcl;
+    }
+    
+    public Boolean getCapabilityAllVersionsSearchable() {
+        return capabilityAllVersionsSearchable;
+    }
+    
+    public void setCapabilityAllVersionsSearchable(Boolean capabilityAllVersionsSearchable) {
+        this.capabilityAllVersionsSearchable = capabilityAllVersionsSearchable;
+    }
+    
+    public String getCapabilityChanges() {
+        return capabilityChanges;
+    }
+    
+    public void setCapabilityChanges(String capabilityChanges) {
+        this.capabilityChanges = capabilityChanges;
+    }
+    
+    public String getCapabilityContentStreamUpdatability() {
+        return capabilityContentStreamUpdatability;
+    }
+    
+    public void setCapabilityContentStreamUpdatability(String capabilityContentStreamUpdatability) {
+        this.capabilityContentStreamUpdatability = capabilityContentStreamUpdatability;
+    }
+    
+    public Boolean getCapabilityGetDescendants() {
+        return capabilityGetDescendants;
+    }
+    
+    public void setCapabilityGetDescendants(Boolean capabilityGetDescendants) {
+        this.capabilityGetDescendants = capabilityGetDescendants;
+    }
+    
+    public Boolean getCapabilityGetFolderTree() {
+        return capabilityGetFolderTree;
+    }
+    
+    public void setCapabilityGetFolderTree(Boolean capabilityGetFolderTree) {
+        this.capabilityGetFolderTree = capabilityGetFolderTree;
+    }
+    
+    public String getCapabilityOrderBy() {
+        return capabilityOrderBy;
+    }
+    
+    public void setCapabilityOrderBy(String capabilityOrderBy) {
+        this.capabilityOrderBy = capabilityOrderBy;
+    }
+    
+    public Boolean getCapabilityMultifiling() {
+        return capabilityMultifiling;
+    }
+    
+    public void setCapabilityMultifiling(Boolean capabilityMultifiling) {
+        this.capabilityMultifiling = capabilityMultifiling;
+    }
+    
+    public Boolean getCapabilityPwcSearchable() {
+        return capabilityPwcSearchable;
+    }
+    
+    public void setCapabilityPwcSearchable(Boolean capabilityPwcSearchable) {
+        this.capabilityPwcSearchable = capabilityPwcSearchable;
+    }
+    
+    public Boolean getCapabilityPwcUpdatable() {
+        return capabilityPwcUpdatable;
+    }
+    
+    public void setCapabilityPwcUpdatable(Boolean capabilityPwcUpdatable) {
+        this.capabilityPwcUpdatable = capabilityPwcUpdatable;
+    }
+    
+    public String getCapabilityQuery() {
+        return capabilityQuery;
+    }
+    
+    public void setCapabilityQuery(String capabilityQuery) {
+        this.capabilityQuery = capabilityQuery;
+    }
+    
+    public String getCapabilityRenditions() {
+        return capabilityRenditions;
+    }
+    
+    public void setCapabilityRenditions(String capabilityRenditions) {
+        this.capabilityRenditions = capabilityRenditions;
+    }
+    
+    public Boolean getCapabilityUnfiling() {
+        return capabilityUnfiling;
+    }
+    
+    public void setCapabilityUnfiling(Boolean capabilityUnfiling) {
+        this.capabilityUnfiling = capabilityUnfiling;
+    }
+    
+    public Boolean getCapabilityVersionSpecificFiling() {
+        return capabilityVersionSpecificFiling;
+    }
+    
+    public void setCapabilityVersionSpecificFiling(Boolean capabilityVersionSpecificFiling) {
+        this.capabilityVersionSpecificFiling = capabilityVersionSpecificFiling;
+    }
+    
+    public String getCapabilityJoin() {
+        return capabilityJoin;
+    }
+    
+    public void setCapabilityJoin(String capabilityJoin) {
+        this.capabilityJoin = capabilityJoin;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryInfoResponse.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/model/response/RepositoryInfoResponse.java
@@ -1,0 +1,207 @@
+package jp.aegif.nemaki.api.v1.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+@Schema(description = "Repository information response")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RepositoryInfoResponse {
+    
+    @Schema(description = "Repository ID", example = "bedroom")
+    @JsonProperty("repositoryId")
+    private String repositoryId;
+    
+    @Schema(description = "Repository name", example = "Bedroom Repository")
+    @JsonProperty("repositoryName")
+    private String repositoryName;
+    
+    @Schema(description = "Repository description", example = "Main content repository")
+    @JsonProperty("repositoryDescription")
+    private String repositoryDescription;
+    
+    @Schema(description = "Vendor name", example = "aegif")
+    @JsonProperty("vendorName")
+    private String vendorName;
+    
+    @Schema(description = "Product name", example = "NemakiWare")
+    @JsonProperty("productName")
+    private String productName;
+    
+    @Schema(description = "Product version", example = "3.0.0")
+    @JsonProperty("productVersion")
+    private String productVersion;
+    
+    @Schema(description = "Root folder ID")
+    @JsonProperty("rootFolderId")
+    private String rootFolderId;
+    
+    @Schema(description = "CMIS version supported", example = "1.1")
+    @JsonProperty("cmisVersionSupported")
+    private String cmisVersionSupported;
+    
+    @Schema(description = "Principal ID for anonymous user")
+    @JsonProperty("principalIdAnonymous")
+    private String principalIdAnonymous;
+    
+    @Schema(description = "Principal ID for anyone")
+    @JsonProperty("principalIdAnyone")
+    private String principalIdAnyone;
+    
+    @Schema(description = "Thin client URI")
+    @JsonProperty("thinClientUri")
+    private String thinClientUri;
+    
+    @Schema(description = "Whether changes on type are supported")
+    @JsonProperty("changesOnType")
+    private Boolean changesOnType;
+    
+    @Schema(description = "Latest change log token")
+    @JsonProperty("latestChangeLogToken")
+    private String latestChangeLogToken;
+    
+    @Schema(description = "Repository capabilities")
+    @JsonProperty("capabilities")
+    private RepositoryCapabilities capabilities;
+    
+    @Schema(description = "ACL capabilities")
+    @JsonProperty("aclCapabilities")
+    private AclCapabilities aclCapabilities;
+    
+    @Schema(description = "HATEOAS links")
+    @JsonProperty("_links")
+    private Map<String, LinkInfo> links;
+    
+    public RepositoryInfoResponse() {
+    }
+    
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+    
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+    
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+    
+    public void setRepositoryName(String repositoryName) {
+        this.repositoryName = repositoryName;
+    }
+    
+    public String getRepositoryDescription() {
+        return repositoryDescription;
+    }
+    
+    public void setRepositoryDescription(String repositoryDescription) {
+        this.repositoryDescription = repositoryDescription;
+    }
+    
+    public String getVendorName() {
+        return vendorName;
+    }
+    
+    public void setVendorName(String vendorName) {
+        this.vendorName = vendorName;
+    }
+    
+    public String getProductName() {
+        return productName;
+    }
+    
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+    
+    public String getProductVersion() {
+        return productVersion;
+    }
+    
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
+    
+    public String getRootFolderId() {
+        return rootFolderId;
+    }
+    
+    public void setRootFolderId(String rootFolderId) {
+        this.rootFolderId = rootFolderId;
+    }
+    
+    public String getCmisVersionSupported() {
+        return cmisVersionSupported;
+    }
+    
+    public void setCmisVersionSupported(String cmisVersionSupported) {
+        this.cmisVersionSupported = cmisVersionSupported;
+    }
+    
+    public String getPrincipalIdAnonymous() {
+        return principalIdAnonymous;
+    }
+    
+    public void setPrincipalIdAnonymous(String principalIdAnonymous) {
+        this.principalIdAnonymous = principalIdAnonymous;
+    }
+    
+    public String getPrincipalIdAnyone() {
+        return principalIdAnyone;
+    }
+    
+    public void setPrincipalIdAnyone(String principalIdAnyone) {
+        this.principalIdAnyone = principalIdAnyone;
+    }
+    
+    public String getThinClientUri() {
+        return thinClientUri;
+    }
+    
+    public void setThinClientUri(String thinClientUri) {
+        this.thinClientUri = thinClientUri;
+    }
+    
+    public Boolean getChangesOnType() {
+        return changesOnType;
+    }
+    
+    public void setChangesOnType(Boolean changesOnType) {
+        this.changesOnType = changesOnType;
+    }
+    
+    public String getLatestChangeLogToken() {
+        return latestChangeLogToken;
+    }
+    
+    public void setLatestChangeLogToken(String latestChangeLogToken) {
+        this.latestChangeLogToken = latestChangeLogToken;
+    }
+    
+    public RepositoryCapabilities getCapabilities() {
+        return capabilities;
+    }
+    
+    public void setCapabilities(RepositoryCapabilities capabilities) {
+        this.capabilities = capabilities;
+    }
+    
+    public AclCapabilities getAclCapabilities() {
+        return aclCapabilities;
+    }
+    
+    public void setAclCapabilities(AclCapabilities aclCapabilities) {
+        this.aclCapabilities = aclCapabilities;
+    }
+    
+    public Map<String, LinkInfo> getLinks() {
+        return links;
+    }
+    
+    public void setLinks(Map<String, LinkInfo> links) {
+        this.links = links;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/AclResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/AclResource.java
@@ -1,0 +1,256 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.request.AclRequest;
+import jp.aegif.nemaki.api.v1.model.response.AclResponse;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.cmis.service.AclService;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.data.Ace;
+import org.apache.chemistry.opencmis.commons.data.Acl;
+import org.apache.chemistry.opencmis.commons.enums.AclPropagation;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.AccessControlEntryImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.AccessControlListImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.AccessControlPrincipalDataImpl;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/objects/{objectId}/acl")
+@Tag(name = "acl", description = "CMIS ACL operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class AclResource {
+    
+    private static final Logger logger = Logger.getLogger(AclResource.class.getName());
+    
+    @Autowired
+    private AclService aclService;
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @GET
+    @Operation(
+            summary = "Get ACL",
+            description = "Gets the ACL currently applied to the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "ACL information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AclResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getAcl(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Only return basic permissions")
+            @QueryParam("onlyBasicPermissions") Boolean onlyBasicPermissions) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Acl acl = aclService.getAcl(callContext, repositoryId, objectId, onlyBasicPermissions, null);
+            
+            if (acl == null) {
+                throw ApiException.objectNotFound(objectId, repositoryId);
+            }
+            
+            AclResponse response = mapToAclResponse(acl, repositoryId, objectId);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting ACL for object " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get ACL: " + e.getMessage(), e);
+        }
+    }
+    
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Apply ACL",
+            description = "Applies a new ACL to the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Updated ACL information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AclResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response applyAcl(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "ACL to apply", required = true)
+            AclRequest aclRequest) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            if (aclRequest == null || aclRequest.getAces() == null || aclRequest.getAces().isEmpty()) {
+                throw ApiException.invalidArgument("ACL entries (aces) are required");
+            }
+            
+            Acl acesToApply = convertToAcl(aclRequest);
+            AclPropagation propagation = parseAclPropagation(aclRequest.getAclPropagation());
+            
+            Acl updatedAcl = aclService.applyAcl(callContext, repositoryId, objectId, acesToApply, propagation);
+            
+            AclResponse response = mapToAclResponse(updatedAcl, repositoryId, objectId);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error applying ACL to object " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to apply ACL: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (repositoryService.getRepositoryInfo(repositoryId) == null) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private AclResponse mapToAclResponse(Acl acl, String repositoryId, String objectId) {
+        AclResponse response = new AclResponse();
+        response.setObjectId(objectId);
+        response.setExact(acl.isExact());
+        
+        List<AclResponse.AceEntry> aces = new ArrayList<>();
+        if (acl.getAces() != null) {
+            for (Ace ace : acl.getAces()) {
+                AclResponse.AceEntry entry = new AclResponse.AceEntry();
+                entry.setPrincipalId(ace.getPrincipalId());
+                entry.setPermissions(ace.getPermissions());
+                entry.setDirect(ace.isDirect());
+                aces.add(entry);
+            }
+        }
+        response.setAces(aces);
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId + "/acl"));
+        links.put("object", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId));
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private Acl convertToAcl(AclRequest request) {
+        AccessControlListImpl acl = new AccessControlListImpl();
+        List<Ace> aces = new ArrayList<>();
+        
+        for (AclRequest.AceEntry entry : request.getAces()) {
+            if (entry.getPrincipalId() == null || entry.getPrincipalId().isEmpty()) {
+                throw ApiException.invalidArgument("Principal ID is required for each ACE");
+            }
+            if (entry.getPermissions() == null || entry.getPermissions().isEmpty()) {
+                throw ApiException.invalidArgument("Permissions are required for each ACE");
+            }
+            
+            AccessControlPrincipalDataImpl principal = new AccessControlPrincipalDataImpl(entry.getPrincipalId());
+            AccessControlEntryImpl ace = new AccessControlEntryImpl(principal, entry.getPermissions());
+            aces.add(ace);
+        }
+        
+        acl.setAces(aces);
+        return acl;
+    }
+    
+    private AclPropagation parseAclPropagation(String propagation) {
+        if (propagation == null || propagation.isEmpty()) {
+            return AclPropagation.REPOSITORYDETERMINED;
+        }
+        try {
+            return AclPropagation.valueOf(propagation.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw ApiException.invalidArgument("Invalid ACL propagation value: " + propagation + 
+                    ". Valid values are: REPOSITORYDETERMINED, OBJECTONLY, PROPAGATE");
+        }
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/DocumentResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/DocumentResource.java
@@ -1,0 +1,1067 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.ObjectListResponse;
+import jp.aegif.nemaki.api.v1.model.response.ObjectResponse;
+import jp.aegif.nemaki.cmis.service.NavigationService;
+import jp.aegif.nemaki.cmis.service.ObjectService;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+import jp.aegif.nemaki.cmis.service.VersioningService;
+
+import org.apache.chemistry.opencmis.commons.PropertyIds;
+import org.apache.chemistry.opencmis.commons.data.ContentStream;
+import org.apache.chemistry.opencmis.commons.data.ObjectData;
+import org.apache.chemistry.opencmis.commons.data.ObjectList;
+import org.apache.chemistry.opencmis.commons.data.Properties;
+import org.apache.chemistry.opencmis.commons.data.PropertyData;
+import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
+import org.apache.chemistry.opencmis.commons.enums.VersioningState;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisUpdateConflictException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisVersioningException;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.ContentStreamImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertiesImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyBooleanImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDateTimeImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDecimalImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyHtmlImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIdImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIntegerImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyStringImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyUriImpl;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.apache.chemistry.opencmis.commons.spi.Holder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/documents")
+@Tag(name = "documents", description = "Document-specific operations including versioning (convenience API)")
+@Produces(MediaType.APPLICATION_JSON)
+public class DocumentResource {
+    
+    private static final Logger logger = Logger.getLogger(DocumentResource.class.getName());
+    private static final SimpleDateFormat ISO_DATE_FORMAT;
+    
+    static {
+        ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+    
+    @Autowired
+    private ObjectService objectService;
+    
+    @Autowired
+    private VersioningService versioningService;
+    
+    @Autowired
+    private NavigationService navigationService;
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Create document",
+            description = "Creates a new document in the specified parent folder"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Document created successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Parent folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response createDocument(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Parent folder ID", required = true)
+            @QueryParam("parentId") String parentId,
+            @Parameter(description = "Versioning state (none, checkedout, minor, major)")
+            @QueryParam("versioningState") @DefaultValue("major") String versioningStateStr,
+            Map<String, PropertyValue> properties) {
+        
+        logger.info("API v1: Creating document in repository " + repositoryId + " under parent " + parentId);
+        
+        try {
+            validateRepository(repositoryId);
+            
+            if (parentId == null || parentId.isEmpty()) {
+                throw ApiException.invalidArgument("parentId is required");
+            }
+            
+            CallContext callContext = getCallContext();
+            Properties cmisProperties = convertToProperties(properties, "cmis:document");
+            
+            VersioningState versioningState = VersioningState.MAJOR;
+            if ("none".equalsIgnoreCase(versioningStateStr)) {
+                versioningState = VersioningState.NONE;
+            } else if ("checkedout".equalsIgnoreCase(versioningStateStr)) {
+                versioningState = VersioningState.CHECKEDOUT;
+            } else if ("minor".equalsIgnoreCase(versioningStateStr)) {
+                versioningState = VersioningState.MINOR;
+            }
+            
+            String documentId = objectService.createDocument(
+                    callContext, repositoryId, cmisProperties, parentId,
+                    null, versioningState, null, null, null, null);
+            
+            ObjectData createdDocument = objectService.getObject(
+                    callContext, repositoryId, documentId, null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            ObjectResponse response = mapToObjectResponse(createdDocument, repositoryId, true);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            return Response.created(java.net.URI.create(baseUri + "repositories/" + repositoryId + "/documents/" + documentId))
+                    .entity(response)
+                    .build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error creating document: " + e.getMessage());
+            throw ApiException.internalError("Failed to create document: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{documentId}")
+    @Operation(
+            summary = "Get document",
+            description = "Gets the specified document information"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Document information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Document not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getDocument(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Document ID", required = true)
+            @PathParam("documentId") String documentId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions) {
+        
+        logger.info("API v1: Getting document " + documentId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ObjectData objectData = objectService.getObject(
+                    callContext, repositoryId, documentId, filter,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, false, false, null);
+            
+            if (objectData == null) {
+                throw ApiException.objectNotFound(documentId, repositoryId);
+            }
+            
+            ObjectResponse response = mapToObjectResponse(objectData, repositoryId, includeAllowableActions);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting document " + documentId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get document: " + e.getMessage(), e);
+        }
+    }
+    
+    @POST
+    @Path("/{documentId}/checkout")
+    @Operation(
+            summary = "Check out document",
+            description = "Creates a private working copy (PWC) of the document"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Document checked out successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Document not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "Document already checked out",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response checkOut(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Document ID", required = true)
+            @PathParam("documentId") String documentId) {
+        
+        logger.info("API v1: Checking out document " + documentId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Holder<String> objectIdHolder = new Holder<>(documentId);
+            Holder<Boolean> contentCopiedHolder = new Holder<>();
+            
+            versioningService.checkOut(callContext, repositoryId, objectIdHolder, contentCopiedHolder, null);
+            
+            String pwcId = objectIdHolder.getValue();
+            
+            ObjectData pwcObject = objectService.getObject(
+                    callContext, repositoryId, pwcId, null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("pwcId", pwcId);
+            response.put("originalObjectId", documentId);
+            response.put("contentCopied", contentCopiedHolder.getValue());
+            
+            Properties props = pwcObject.getProperties();
+            if (props != null) {
+                response.put("versionSeriesId", getStringProperty(props, PropertyIds.VERSION_SERIES_ID));
+                response.put("versionSeriesCheckedOutId", getStringProperty(props, PropertyIds.VERSION_SERIES_CHECKED_OUT_ID));
+                response.put("versionSeriesCheckedOutBy", getStringProperty(props, PropertyIds.VERSION_SERIES_CHECKED_OUT_BY));
+                response.put("isVersionSeriesCheckedOut", getBooleanProperty(props, PropertyIds.IS_VERSION_SERIES_CHECKED_OUT));
+            }
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("pwc", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + pwcId));
+            links.put("original", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + documentId));
+            links.put("checkin", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + pwcId + "/checkin"));
+            links.put("cancelCheckout", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + pwcId + "/cancelCheckout"));
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (CmisUpdateConflictException e) {
+            logger.warning("Document already checked out: " + documentId);
+            throw ApiException.conflict("Document is already checked out");
+        } catch (CmisVersioningException e) {
+            logger.warning("Versioning error checking out document " + documentId + ": " + e.getMessage());
+            throw ApiException.conflict("Versioning conflict: " + e.getMessage());
+        } catch (Exception e) {
+            logger.severe("Error checking out document " + documentId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to check out document: " + e.getMessage(), e);
+        }
+    }
+    
+    @POST
+    @Path("/{documentId}/checkin")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Check in document",
+            description = "Checks in the private working copy (PWC) and creates a new version"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Document checked in successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Document not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Document is not checked out",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response checkIn(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "PWC Document ID", required = true)
+            @PathParam("documentId") String documentId,
+            @Parameter(description = "Create major version")
+            @QueryParam("major") @DefaultValue("true") Boolean major,
+            @Parameter(description = "Checkin comment")
+            @QueryParam("checkinComment") String checkinComment,
+            Map<String, PropertyValue> properties) {
+        
+        logger.info("API v1: Checking in document " + documentId + " to repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Holder<String> objectIdHolder = new Holder<>(documentId);
+            Properties cmisProperties = properties != null && !properties.isEmpty() 
+                    ? convertToProperties(properties, null) : null;
+            
+            versioningService.checkIn(callContext, repositoryId, objectIdHolder, major,
+                    cmisProperties, null, checkinComment, null, null, null, null);
+            
+            String newVersionId = objectIdHolder.getValue();
+            
+            ObjectData newVersionObject = objectService.getObject(
+                    callContext, repositoryId, newVersionId, null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("objectId", newVersionId);
+            response.put("isMajorVersion", major);
+            response.put("checkinComment", checkinComment);
+            
+            Properties props = newVersionObject.getProperties();
+            if (props != null) {
+                response.put("versionSeriesId", getStringProperty(props, PropertyIds.VERSION_SERIES_ID));
+                response.put("versionLabel", getStringProperty(props, PropertyIds.VERSION_LABEL));
+                response.put("isLatestVersion", getBooleanProperty(props, PropertyIds.IS_LATEST_VERSION));
+                response.put("isLatestMajorVersion", getBooleanProperty(props, PropertyIds.IS_LATEST_MAJOR_VERSION));
+            }
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + newVersionId));
+            links.put("content", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + newVersionId + "/content"));
+            
+            String versionSeriesId = getStringProperty(props, PropertyIds.VERSION_SERIES_ID);
+            if (versionSeriesId != null) {
+                links.put("versionSeries", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + versionSeriesId + "/versions"));
+            }
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (CmisVersioningException e) {
+            logger.warning("Versioning error checking in document " + documentId + ": " + e.getMessage());
+            throw ApiException.invalidArgument("Document is not checked out or versioning error: " + e.getMessage());
+        } catch (CmisUpdateConflictException e) {
+            logger.warning("Update conflict checking in document " + documentId + ": " + e.getMessage());
+            throw ApiException.conflict("Update conflict: " + e.getMessage());
+        } catch (Exception e) {
+            logger.severe("Error checking in document " + documentId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to check in document: " + e.getMessage(), e);
+        }
+    }
+    
+    @POST
+    @Path("/{documentId}/cancelCheckout")
+    @Operation(
+            summary = "Cancel checkout",
+            description = "Cancels the checkout and deletes the private working copy (PWC)"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Checkout cancelled successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Document not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Document is not checked out",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response cancelCheckOut(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "PWC Document ID", required = true)
+            @PathParam("documentId") String documentId) {
+        
+        logger.info("API v1: Cancelling checkout for document " + documentId + " in repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ObjectData pwcObject = objectService.getObject(
+                    callContext, repositoryId, documentId, null,
+                    false, IncludeRelationships.NONE, null, false, false, null);
+            
+            String versionSeriesId = null;
+            if (pwcObject != null && pwcObject.getProperties() != null) {
+                versionSeriesId = getStringProperty(pwcObject.getProperties(), PropertyIds.VERSION_SERIES_ID);
+            }
+            
+            versioningService.cancelCheckOut(callContext, repositoryId, documentId, null);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("cancelledPwcId", documentId);
+            response.put("versionSeriesId", versionSeriesId);
+            response.put("isVersionSeriesCheckedOut", false);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            if (versionSeriesId != null) {
+                links.put("versionSeries", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + versionSeriesId + "/versions"));
+            }
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (CmisVersioningException e) {
+            logger.warning("Versioning error cancelling checkout for document " + documentId + ": " + e.getMessage());
+            throw ApiException.invalidArgument("Document is not checked out or versioning error: " + e.getMessage());
+        } catch (CmisUpdateConflictException e) {
+            logger.warning("Update conflict cancelling checkout for document " + documentId + ": " + e.getMessage());
+            throw ApiException.conflict("Update conflict: " + e.getMessage());
+        } catch (Exception e) {
+            logger.severe("Error cancelling checkout for document " + documentId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to cancel checkout: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{documentId}/versions")
+    @Operation(
+            summary = "Get all versions",
+            description = "Gets all versions of the specified document"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of document versions",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectListResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Document not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getAllVersions(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Document ID or Version Series ID", required = true)
+            @PathParam("documentId") String documentId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions) {
+        
+        logger.info("API v1: Getting all versions for document " + documentId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            List<ObjectData> versions = versioningService.getAllVersions(
+                    callContext, repositoryId, documentId, null,
+                    filter, includeAllowableActions, null);
+            
+            List<ObjectResponse> versionResponses = new ArrayList<>();
+            if (versions != null) {
+                for (ObjectData version : versions) {
+                    versionResponses.add(mapToObjectResponse(version, repositoryId, includeAllowableActions));
+                }
+            }
+            
+            ObjectListResponse response = new ObjectListResponse();
+            response.setObjects(versionResponses);
+            response.setNumItems((long) versionResponses.size());
+            response.setHasMoreItems(false);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + documentId + "/versions"));
+            links.put("document", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + documentId));
+            response.setLinks(links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting versions for document " + documentId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get document versions: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{documentId}/latestVersion")
+    @Operation(
+            summary = "Get latest version",
+            description = "Gets the latest version of the specified document"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Latest version information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Document not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getLatestVersion(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Document ID or Version Series ID", required = true)
+            @PathParam("documentId") String documentId,
+            @Parameter(description = "Get latest major version only")
+            @QueryParam("major") @DefaultValue("false") Boolean major,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions) {
+        
+        logger.info("API v1: Getting latest version for document " + documentId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ObjectData latestVersion = versioningService.getObjectOfLatestVersion(
+                    callContext, repositoryId, documentId, null, major,
+                    filter, includeAllowableActions, IncludeRelationships.NONE,
+                    null, false, false, null);
+            
+            if (latestVersion == null) {
+                throw ApiException.objectNotFound(documentId, repositoryId);
+            }
+            
+            ObjectResponse response = mapToObjectResponse(latestVersion, repositoryId, includeAllowableActions);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting latest version for document " + documentId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get latest version: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/checkedout")
+    @Operation(
+            summary = "Get checked out documents",
+            description = "Gets all documents that are currently checked out"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of checked out documents",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectListResponse.class)
+                    )
+            )
+    })
+    public Response getCheckedOutDocs(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Folder ID to limit search (optional)")
+            @QueryParam("folderId") String folderId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Order by clause", example = "cmis:lastModificationDate DESC")
+            @QueryParam("orderBy") String orderBy,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems,
+            @Parameter(description = "Number of items to skip")
+            @QueryParam("skipCount") @DefaultValue("0") Integer skipCount) {
+        
+        logger.info("API v1: Getting checked out documents from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ObjectList checkedOutDocs = navigationService.getCheckedOutDocs(
+                    callContext, repositoryId, folderId, filter, orderBy,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, BigInteger.valueOf(maxItems), BigInteger.valueOf(skipCount), null);
+            
+            List<ObjectResponse> docResponses = new ArrayList<>();
+            if (checkedOutDocs != null && checkedOutDocs.getObjects() != null) {
+                for (ObjectData doc : checkedOutDocs.getObjects()) {
+                    docResponses.add(mapToObjectResponse(doc, repositoryId, includeAllowableActions));
+                }
+            }
+            
+            ObjectListResponse response = new ObjectListResponse();
+            response.setObjects(docResponses);
+            response.setNumItems(checkedOutDocs != null && checkedOutDocs.getNumItems() != null 
+                    ? checkedOutDocs.getNumItems().longValue() : (long) docResponses.size());
+            response.setHasMoreItems(checkedOutDocs != null && checkedOutDocs.hasMoreItems() != null 
+                    ? checkedOutDocs.hasMoreItems() : false);
+            response.setSkipCount((long) skipCount);
+            response.setMaxItems((long) maxItems);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/checkedout?maxItems=" + maxItems + "&skipCount=" + skipCount));
+            
+            if (response.getHasMoreItems()) {
+                int nextSkip = skipCount + maxItems;
+                links.put("next", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/checkedout?maxItems=" + maxItems + "&skipCount=" + nextSkip));
+            }
+            if (skipCount > 0) {
+                int prevSkip = Math.max(0, skipCount - maxItems);
+                links.put("prev", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/checkedout?maxItems=" + maxItems + "&skipCount=" + prevSkip));
+            }
+            
+            response.setLinks(links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting checked out documents: " + e.getMessage());
+            throw ApiException.internalError("Failed to get checked out documents: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private ObjectResponse mapToObjectResponse(ObjectData objectData, String repositoryId, Boolean includeAllowableActions) {
+        ObjectResponse response = new ObjectResponse();
+        
+        Properties properties = objectData.getProperties();
+        if (properties != null) {
+            response.setObjectId(getStringProperty(properties, PropertyIds.OBJECT_ID));
+            response.setBaseTypeId(getStringProperty(properties, PropertyIds.BASE_TYPE_ID));
+            response.setObjectTypeId(getStringProperty(properties, PropertyIds.OBJECT_TYPE_ID));
+            response.setName(getStringProperty(properties, PropertyIds.NAME));
+            response.setDescription(getStringProperty(properties, PropertyIds.DESCRIPTION));
+            response.setCreatedBy(getStringProperty(properties, PropertyIds.CREATED_BY));
+            response.setCreationDate(getDateProperty(properties, PropertyIds.CREATION_DATE));
+            response.setLastModifiedBy(getStringProperty(properties, PropertyIds.LAST_MODIFIED_BY));
+            response.setLastModificationDate(getDateProperty(properties, PropertyIds.LAST_MODIFICATION_DATE));
+            response.setChangeToken(getStringProperty(properties, PropertyIds.CHANGE_TOKEN));
+            response.setParentId(getStringProperty(properties, PropertyIds.PARENT_ID));
+            
+            response.setIsLatestVersion(getBooleanProperty(properties, PropertyIds.IS_LATEST_VERSION));
+            response.setIsLatestMajorVersion(getBooleanProperty(properties, PropertyIds.IS_LATEST_MAJOR_VERSION));
+            response.setIsMajorVersion(getBooleanProperty(properties, PropertyIds.IS_MAJOR_VERSION));
+            response.setVersionLabel(getStringProperty(properties, PropertyIds.VERSION_LABEL));
+            response.setVersionSeriesId(getStringProperty(properties, PropertyIds.VERSION_SERIES_ID));
+            response.setIsVersionSeriesCheckedOut(getBooleanProperty(properties, PropertyIds.IS_VERSION_SERIES_CHECKED_OUT));
+            response.setVersionSeriesCheckedOutBy(getStringProperty(properties, PropertyIds.VERSION_SERIES_CHECKED_OUT_BY));
+            response.setVersionSeriesCheckedOutId(getStringProperty(properties, PropertyIds.VERSION_SERIES_CHECKED_OUT_ID));
+            response.setCheckinComment(getStringProperty(properties, PropertyIds.CHECKIN_COMMENT));
+            
+            response.setContentStreamLength(getLongProperty(properties, PropertyIds.CONTENT_STREAM_LENGTH));
+            response.setContentStreamMimeType(getStringProperty(properties, PropertyIds.CONTENT_STREAM_MIME_TYPE));
+            response.setContentStreamFileName(getStringProperty(properties, PropertyIds.CONTENT_STREAM_FILE_NAME));
+            response.setContentStreamId(getStringProperty(properties, PropertyIds.CONTENT_STREAM_ID));
+            
+            Map<String, PropertyValue> propertyMap = new HashMap<>();
+            for (PropertyData<?> prop : properties.getPropertyList()) {
+                propertyMap.put(prop.getId(), mapPropertyValue(prop));
+            }
+            response.setProperties(propertyMap);
+        }
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        String objectId = response.getObjectId();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + objectId));
+        links.put("content", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId + "/content"));
+        links.put("versions", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + objectId + "/versions"));
+        links.put("latestVersion", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + objectId + "/latestVersion"));
+        links.put("checkout", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + objectId + "/checkout"));
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private String getStringProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            return prop.getFirstValue().toString();
+        }
+        return null;
+    }
+    
+    private Boolean getBooleanProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof Boolean) {
+            return (Boolean) prop.getFirstValue();
+        }
+        return null;
+    }
+    
+    private Long getLongProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            Object value = prop.getFirstValue();
+            if (value instanceof Long) {
+                return (Long) value;
+            } else if (value instanceof BigInteger) {
+                return ((BigInteger) value).longValue();
+            } else if (value instanceof Number) {
+                return ((Number) value).longValue();
+            }
+        }
+        return null;
+    }
+    
+    private String getDateProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                return ISO_DATE_FORMAT.format(cal.getTime());
+            }
+        }
+        return null;
+    }
+    
+    private PropertyValue mapPropertyValue(PropertyData<?> prop) {
+        Object value = prop.getValues() != null && prop.getValues().size() > 1 
+                ? prop.getValues() 
+                : prop.getFirstValue();
+        
+        String type = "string";
+        if (prop.getFirstValue() instanceof Boolean) {
+            type = "boolean";
+        } else if (prop.getFirstValue() instanceof Long || prop.getFirstValue() instanceof Integer || prop.getFirstValue() instanceof BigInteger) {
+            type = "integer";
+        } else if (prop.getFirstValue() instanceof Double || prop.getFirstValue() instanceof Float || prop.getFirstValue() instanceof BigDecimal) {
+            type = "decimal";
+        } else if (prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                value = ISO_DATE_FORMAT.format(cal.getTime());
+            }
+            type = "datetime";
+        }
+        
+        PropertyValue pv = new PropertyValue(value, type);
+        pv.setPropertyDefinitionId(prop.getId());
+        pv.setLocalName(prop.getLocalName());
+        pv.setDisplayName(prop.getDisplayName());
+        pv.setQueryName(prop.getQueryName());
+        
+        return pv;
+    }
+    
+    private Properties convertToProperties(Map<String, PropertyValue> propertyMap, String defaultTypeId) {
+        PropertiesImpl properties = new PropertiesImpl();
+        
+        if (propertyMap != null) {
+            for (Map.Entry<String, PropertyValue> entry : propertyMap.entrySet()) {
+                String propertyId = entry.getKey();
+                PropertyValue pv = entry.getValue();
+                
+                if (pv == null || pv.getValue() == null) {
+                    continue;
+                }
+                
+                String type = pv.getType() != null ? pv.getType() : "string";
+                Object value = pv.getValue();
+                boolean isMultiValued = "multi".equals(pv.getCardinality()) || value instanceof List;
+                
+                switch (type) {
+                    case "id":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyIdImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyIdImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "boolean":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBooleanList(value)));
+                        } else {
+                            properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBoolean(value)));
+                        }
+                        break;
+                    case "integer":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigIntegerList(value)));
+                        } else {
+                            properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigInteger(value)));
+                        }
+                        break;
+                    case "decimal":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimalList(value)));
+                        } else {
+                            properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimal(value)));
+                        }
+                        break;
+                    case "datetime":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendarList(value)));
+                        } else {
+                            properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendar(value)));
+                        }
+                        break;
+                    case "html":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyHtmlImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyHtmlImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "uri":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyUriImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyUriImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "string":
+                    default:
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyStringImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyStringImpl(propertyId, value.toString()));
+                        }
+                        break;
+                }
+            }
+        }
+        
+        if (defaultTypeId != null && !properties.getProperties().containsKey(PropertyIds.OBJECT_TYPE_ID)) {
+            properties.addProperty(new PropertyIdImpl(PropertyIds.OBJECT_TYPE_ID, defaultTypeId));
+        }
+        
+        return properties;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<String> convertToStringList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<String> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(item != null ? item.toString() : null);
+            }
+            return result;
+        }
+        return List.of(value.toString());
+    }
+    
+    private Boolean convertToBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<Boolean> convertToBooleanList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<Boolean> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBoolean(item));
+            }
+            return result;
+        }
+        return List.of(convertToBoolean(value));
+    }
+    
+    private BigInteger convertToBigInteger(Object value) {
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof Number) {
+            return BigInteger.valueOf(((Number) value).longValue());
+        }
+        return new BigInteger(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<BigInteger> convertToBigIntegerList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigInteger> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigInteger(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigInteger(value));
+    }
+    
+    private BigDecimal convertToBigDecimal(Object value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<BigDecimal> convertToBigDecimalList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigDecimal> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigDecimal(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigDecimal(value));
+    }
+    
+    private GregorianCalendar convertToCalendar(Object value) {
+        if (value instanceof GregorianCalendar) {
+            return (GregorianCalendar) value;
+        }
+        String dateStr = value.toString();
+        try {
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+            calendar.setTime(ISO_DATE_FORMAT.parse(dateStr));
+            return calendar;
+        } catch (ParseException e) {
+            logger.warning("Failed to parse datetime: " + dateStr);
+            throw ApiException.invalidArgument("Invalid datetime format: " + dateStr + ". Expected ISO 8601 format (e.g., 2024-01-15T10:30:00Z)");
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<GregorianCalendar> convertToCalendarList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<GregorianCalendar> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToCalendar(item));
+            }
+            return result;
+        }
+        return List.of(convertToCalendar(value));
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/FolderResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/FolderResource.java
@@ -1,0 +1,922 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.ObjectListResponse;
+import jp.aegif.nemaki.api.v1.model.response.ObjectResponse;
+import jp.aegif.nemaki.cmis.service.NavigationService;
+import jp.aegif.nemaki.cmis.service.ObjectService;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.PropertyIds;
+import org.apache.chemistry.opencmis.commons.data.FailedToDeleteData;
+import org.apache.chemistry.opencmis.commons.data.ObjectData;
+import org.apache.chemistry.opencmis.commons.data.ObjectInFolderContainer;
+import org.apache.chemistry.opencmis.commons.data.ObjectInFolderData;
+import org.apache.chemistry.opencmis.commons.data.ObjectInFolderList;
+import org.apache.chemistry.opencmis.commons.data.Properties;
+import org.apache.chemistry.opencmis.commons.data.PropertyData;
+import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
+import org.apache.chemistry.opencmis.commons.enums.UnfileObject;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertiesImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyBooleanImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDateTimeImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDecimalImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyHtmlImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIdImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIntegerImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyStringImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyUriImpl;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.apache.chemistry.opencmis.commons.spi.Holder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/folders")
+@Tag(name = "folders", description = "Folder-specific operations (convenience API)")
+@Produces(MediaType.APPLICATION_JSON)
+public class FolderResource {
+    
+    private static final Logger logger = Logger.getLogger(FolderResource.class.getName());
+    private static final SimpleDateFormat ISO_DATE_FORMAT;
+    
+    static {
+        ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+    
+    @Autowired
+    private ObjectService objectService;
+    
+    @Autowired
+    private NavigationService navigationService;
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Create folder",
+            description = "Creates a new folder in the specified parent folder"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Folder created successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Parent folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response createFolder(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Parent folder ID", required = true)
+            @QueryParam("parentId") String parentId,
+            Map<String, PropertyValue> properties) {
+        
+        logger.info("API v1: Creating folder in repository " + repositoryId + " under parent " + parentId);
+        
+        try {
+            validateRepository(repositoryId);
+            
+            if (parentId == null || parentId.isEmpty()) {
+                throw ApiException.invalidArgument("parentId is required");
+            }
+            
+            CallContext callContext = getCallContext();
+            Properties cmisProperties = convertToProperties(properties);
+            
+            String folderId = objectService.createFolder(
+                    callContext, repositoryId, cmisProperties, parentId,
+                    null, null, null, null);
+            
+            ObjectData createdFolder = objectService.getObject(
+                    callContext, repositoryId, folderId, null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            ObjectResponse response = mapToObjectResponse(createdFolder, repositoryId, true);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            return Response.created(java.net.URI.create(baseUri + "repositories/" + repositoryId + "/folders/" + folderId))
+                    .entity(response)
+                    .build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error creating folder: " + e.getMessage());
+            throw ApiException.internalError("Failed to create folder: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{folderId}")
+    @Operation(
+            summary = "Get folder",
+            description = "Gets the specified folder information"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Folder information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getFolder(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Folder ID", required = true)
+            @PathParam("folderId") String folderId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions) {
+        
+        logger.info("API v1: Getting folder " + folderId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ObjectData objectData = objectService.getObject(
+                    callContext, repositoryId, folderId, filter,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, false, false, null);
+            
+            if (objectData == null) {
+                throw ApiException.objectNotFound(folderId, repositoryId);
+            }
+            
+            ObjectResponse response = mapToObjectResponse(objectData, repositoryId, includeAllowableActions);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting folder " + folderId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get folder: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{folderId}/children")
+    @Operation(
+            summary = "Get folder children",
+            description = "Gets the list of child objects contained in the specified folder"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of child objects",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectListResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getChildren(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Folder ID", required = true)
+            @PathParam("folderId") String folderId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Order by clause", example = "cmis:name ASC")
+            @QueryParam("orderBy") String orderBy,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Include path segments")
+            @QueryParam("includePathSegments") @DefaultValue("false") Boolean includePathSegments,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems,
+            @Parameter(description = "Number of items to skip")
+            @QueryParam("skipCount") @DefaultValue("0") Integer skipCount) {
+        
+        logger.info("API v1: Getting children of folder " + folderId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Holder<ObjectData> parentHolder = new Holder<>();
+            ObjectInFolderList children = navigationService.getChildren(
+                    callContext, repositoryId, folderId, filter, orderBy,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, includePathSegments,
+                    BigInteger.valueOf(maxItems), BigInteger.valueOf(skipCount),
+                    parentHolder, null);
+            
+            List<ObjectResponse> childResponses = new ArrayList<>();
+            if (children != null && children.getObjects() != null) {
+                for (ObjectInFolderData child : children.getObjects()) {
+                    if (child.getObject() != null) {
+                        childResponses.add(mapToObjectResponse(child.getObject(), repositoryId, includeAllowableActions));
+                    }
+                }
+            }
+            
+            ObjectListResponse response = new ObjectListResponse();
+            response.setObjects(childResponses);
+            response.setNumItems(children != null && children.getNumItems() != null 
+                    ? children.getNumItems().longValue() : (long) childResponses.size());
+            response.setHasMoreItems(children != null && children.hasMoreItems() != null 
+                    ? children.hasMoreItems() : false);
+            response.setSkipCount((long) skipCount);
+            response.setMaxItems((long) maxItems);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId + "/children?maxItems=" + maxItems + "&skipCount=" + skipCount));
+            links.put("folder", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId));
+            
+            if (response.getHasMoreItems()) {
+                int nextSkip = skipCount + maxItems;
+                links.put("next", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId + "/children?maxItems=" + maxItems + "&skipCount=" + nextSkip));
+            }
+            if (skipCount > 0) {
+                int prevSkip = Math.max(0, skipCount - maxItems);
+                links.put("prev", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId + "/children?maxItems=" + maxItems + "&skipCount=" + prevSkip));
+            }
+            
+            response.setLinks(links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting children of folder " + folderId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get folder children: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{folderId}/descendants")
+    @Operation(
+            summary = "Get folder descendants",
+            description = "Gets the set of descendant objects contained in the specified folder or any of its child folders"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Tree of descendant objects",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getDescendants(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Folder ID", required = true)
+            @PathParam("folderId") String folderId,
+            @Parameter(description = "Depth of descendants to return (-1 for all)")
+            @QueryParam("depth") @DefaultValue("-1") Integer depth,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Include path segments")
+            @QueryParam("includePathSegments") @DefaultValue("false") Boolean includePathSegments) {
+        
+        logger.info("API v1: Getting descendants of folder " + folderId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Holder<ObjectData> ancestorHolder = new Holder<>();
+            List<ObjectInFolderContainer> descendants = navigationService.getDescendants(
+                    callContext, repositoryId, folderId, BigInteger.valueOf(depth),
+                    filter, includeAllowableActions, IncludeRelationships.NONE,
+                    null, includePathSegments, false, ancestorHolder, null);
+            
+            List<Map<String, Object>> descendantTree = mapDescendants(descendants, repositoryId, includeAllowableActions);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("folderId", folderId);
+            response.put("depth", depth);
+            response.put("descendants", descendantTree);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId + "/descendants?depth=" + depth));
+            links.put("folder", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId));
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting descendants of folder " + folderId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get folder descendants: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{folderId}/tree")
+    @Operation(
+            summary = "Get folder tree",
+            description = "Gets the set of descendant folder objects contained in the specified folder"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Tree of descendant folders",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getFolderTree(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Folder ID", required = true)
+            @PathParam("folderId") String folderId,
+            @Parameter(description = "Depth of tree to return (-1 for all)")
+            @QueryParam("depth") @DefaultValue("-1") Integer depth,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Include path segments")
+            @QueryParam("includePathSegments") @DefaultValue("false") Boolean includePathSegments) {
+        
+        logger.info("API v1: Getting folder tree for " + folderId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Holder<ObjectData> ancestorHolder = new Holder<>();
+            List<ObjectInFolderContainer> folderTree = navigationService.getDescendants(
+                    callContext, repositoryId, folderId, BigInteger.valueOf(depth),
+                    filter, includeAllowableActions, IncludeRelationships.NONE,
+                    null, includePathSegments, true, ancestorHolder, null);
+            
+            List<Map<String, Object>> tree = mapDescendants(folderTree, repositoryId, includeAllowableActions);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("folderId", folderId);
+            response.put("depth", depth);
+            response.put("tree", tree);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId + "/tree?depth=" + depth));
+            links.put("folder", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + folderId));
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting folder tree for " + folderId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get folder tree: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{folderId}/parent")
+    @Operation(
+            summary = "Get folder parent",
+            description = "Gets the parent folder object for the specified folder"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Parent folder information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Folder not found or is root folder",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getFolderParent(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Folder ID", required = true)
+            @PathParam("folderId") String folderId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter) {
+        
+        logger.info("API v1: Getting parent of folder " + folderId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ObjectData parent = navigationService.getFolderParent(
+                    callContext, repositoryId, folderId, filter, null);
+            
+            if (parent == null) {
+                throw ApiException.objectNotFound(folderId + " (parent)", repositoryId);
+            }
+            
+            ObjectResponse response = mapToObjectResponse(parent, repositoryId, false);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting parent of folder " + folderId + ": " + e.getMessage());
+            if (e.getMessage() != null && e.getMessage().contains("root")) {
+                throw ApiException.invalidArgument("Root folder has no parent");
+            }
+            throw ApiException.internalError("Failed to get folder parent: " + e.getMessage(), e);
+        }
+    }
+    
+    @DELETE
+    @Path("/{folderId}/tree")
+    @Operation(
+            summary = "Delete folder tree",
+            description = "Deletes the specified folder and all of its child and descendant objects"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Folder tree deleted (may contain failed deletions)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response deleteTree(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Folder ID", required = true)
+            @PathParam("folderId") String folderId,
+            @Parameter(description = "Delete all versions of documents")
+            @QueryParam("allVersions") @DefaultValue("true") Boolean allVersions,
+            @Parameter(description = "How to handle unfiling (unfile, deletesinglefiled, delete)")
+            @QueryParam("unfileObjects") @DefaultValue("delete") String unfileObjects,
+            @Parameter(description = "Continue on failure")
+            @QueryParam("continueOnFailure") @DefaultValue("false") Boolean continueOnFailure) {
+        
+        logger.info("API v1: Deleting tree for folder " + folderId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            UnfileObject unfileOption = UnfileObject.DELETE;
+            if ("unfile".equalsIgnoreCase(unfileObjects)) {
+                unfileOption = UnfileObject.UNFILE;
+            } else if ("deletesinglefiled".equalsIgnoreCase(unfileObjects)) {
+                unfileOption = UnfileObject.DELETESINGLEFILED;
+            }
+            
+            FailedToDeleteData failedToDelete = objectService.deleteTree(
+                    callContext, repositoryId, folderId, allVersions,
+                    unfileOption, continueOnFailure, null);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("folderId", folderId);
+            
+            if (failedToDelete != null && failedToDelete.getIds() != null && !failedToDelete.getIds().isEmpty()) {
+                response.put("success", false);
+                response.put("failedToDeleteIds", failedToDelete.getIds());
+            }
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error deleting tree for folder " + folderId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to delete folder tree: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private List<Map<String, Object>> mapDescendants(List<ObjectInFolderContainer> containers, 
+            String repositoryId, Boolean includeAllowableActions) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        
+        if (containers != null) {
+            for (ObjectInFolderContainer container : containers) {
+                Map<String, Object> item = new HashMap<>();
+                
+                if (container.getObject() != null && container.getObject().getObject() != null) {
+                    item.put("object", mapToObjectResponse(container.getObject().getObject(), 
+                            repositoryId, includeAllowableActions));
+                    
+                    if (container.getObject().getPathSegment() != null) {
+                        item.put("pathSegment", container.getObject().getPathSegment());
+                    }
+                }
+                
+                if (container.getChildren() != null && !container.getChildren().isEmpty()) {
+                    item.put("children", mapDescendants(container.getChildren(), repositoryId, includeAllowableActions));
+                }
+                
+                result.add(item);
+            }
+        }
+        
+        return result;
+    }
+    
+    private ObjectResponse mapToObjectResponse(ObjectData objectData, String repositoryId, Boolean includeAllowableActions) {
+        ObjectResponse response = new ObjectResponse();
+        
+        Properties properties = objectData.getProperties();
+        if (properties != null) {
+            response.setObjectId(getStringProperty(properties, PropertyIds.OBJECT_ID));
+            response.setBaseTypeId(getStringProperty(properties, PropertyIds.BASE_TYPE_ID));
+            response.setObjectTypeId(getStringProperty(properties, PropertyIds.OBJECT_TYPE_ID));
+            response.setName(getStringProperty(properties, PropertyIds.NAME));
+            response.setDescription(getStringProperty(properties, PropertyIds.DESCRIPTION));
+            response.setCreatedBy(getStringProperty(properties, PropertyIds.CREATED_BY));
+            response.setCreationDate(getDateProperty(properties, PropertyIds.CREATION_DATE));
+            response.setLastModifiedBy(getStringProperty(properties, PropertyIds.LAST_MODIFIED_BY));
+            response.setLastModificationDate(getDateProperty(properties, PropertyIds.LAST_MODIFICATION_DATE));
+            response.setChangeToken(getStringProperty(properties, PropertyIds.CHANGE_TOKEN));
+            response.setParentId(getStringProperty(properties, PropertyIds.PARENT_ID));
+            response.setPath(getStringProperty(properties, PropertyIds.PATH));
+            
+            Map<String, PropertyValue> propertyMap = new HashMap<>();
+            for (PropertyData<?> prop : properties.getPropertyList()) {
+                propertyMap.put(prop.getId(), mapPropertyValue(prop));
+            }
+            response.setProperties(propertyMap);
+        }
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        String objectId = response.getObjectId();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + objectId));
+        links.put("children", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + objectId + "/children"));
+        links.put("descendants", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + objectId + "/descendants"));
+        links.put("tree", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + objectId + "/tree"));
+        links.put("parent", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + objectId + "/parent"));
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private String getStringProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            return prop.getFirstValue().toString();
+        }
+        return null;
+    }
+    
+    private String getDateProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                return ISO_DATE_FORMAT.format(cal.getTime());
+            }
+        }
+        return null;
+    }
+    
+    private PropertyValue mapPropertyValue(PropertyData<?> prop) {
+        Object value = prop.getValues() != null && prop.getValues().size() > 1 
+                ? prop.getValues() 
+                : prop.getFirstValue();
+        
+        String type = "string";
+        if (prop.getFirstValue() instanceof Boolean) {
+            type = "boolean";
+        } else if (prop.getFirstValue() instanceof Long || prop.getFirstValue() instanceof Integer || prop.getFirstValue() instanceof BigInteger) {
+            type = "integer";
+        } else if (prop.getFirstValue() instanceof Double || prop.getFirstValue() instanceof Float || prop.getFirstValue() instanceof BigDecimal) {
+            type = "decimal";
+        } else if (prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                value = ISO_DATE_FORMAT.format(cal.getTime());
+            }
+            type = "datetime";
+        }
+        
+        PropertyValue pv = new PropertyValue(value, type);
+        pv.setPropertyDefinitionId(prop.getId());
+        pv.setLocalName(prop.getLocalName());
+        pv.setDisplayName(prop.getDisplayName());
+        pv.setQueryName(prop.getQueryName());
+        
+        return pv;
+    }
+    
+    private Properties convertToProperties(Map<String, PropertyValue> propertyMap) {
+        PropertiesImpl properties = new PropertiesImpl();
+        
+        if (propertyMap != null) {
+            for (Map.Entry<String, PropertyValue> entry : propertyMap.entrySet()) {
+                String propertyId = entry.getKey();
+                PropertyValue pv = entry.getValue();
+                
+                if (pv == null || pv.getValue() == null) {
+                    continue;
+                }
+                
+                String type = pv.getType() != null ? pv.getType() : "string";
+                Object value = pv.getValue();
+                boolean isMultiValued = "multi".equals(pv.getCardinality()) || value instanceof List;
+                
+                switch (type) {
+                    case "id":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyIdImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyIdImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "boolean":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBooleanList(value)));
+                        } else {
+                            properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBoolean(value)));
+                        }
+                        break;
+                    case "integer":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigIntegerList(value)));
+                        } else {
+                            properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigInteger(value)));
+                        }
+                        break;
+                    case "decimal":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimalList(value)));
+                        } else {
+                            properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimal(value)));
+                        }
+                        break;
+                    case "datetime":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendarList(value)));
+                        } else {
+                            properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendar(value)));
+                        }
+                        break;
+                    case "html":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyHtmlImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyHtmlImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "uri":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyUriImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyUriImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "string":
+                    default:
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyStringImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyStringImpl(propertyId, value.toString()));
+                        }
+                        break;
+                }
+            }
+        }
+        
+        if (!properties.getProperties().containsKey(PropertyIds.OBJECT_TYPE_ID)) {
+            properties.addProperty(new PropertyIdImpl(PropertyIds.OBJECT_TYPE_ID, "cmis:folder"));
+        }
+        
+        return properties;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<String> convertToStringList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<String> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(item != null ? item.toString() : null);
+            }
+            return result;
+        }
+        return List.of(value.toString());
+    }
+    
+    private Boolean convertToBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<Boolean> convertToBooleanList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<Boolean> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBoolean(item));
+            }
+            return result;
+        }
+        return List.of(convertToBoolean(value));
+    }
+    
+    private BigInteger convertToBigInteger(Object value) {
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof Number) {
+            return BigInteger.valueOf(((Number) value).longValue());
+        }
+        return new BigInteger(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<BigInteger> convertToBigIntegerList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigInteger> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigInteger(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigInteger(value));
+    }
+    
+    private BigDecimal convertToBigDecimal(Object value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<BigDecimal> convertToBigDecimalList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigDecimal> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigDecimal(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigDecimal(value));
+    }
+    
+    private GregorianCalendar convertToCalendar(Object value) {
+        if (value instanceof GregorianCalendar) {
+            return (GregorianCalendar) value;
+        }
+        String dateStr = value.toString();
+        try {
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+            calendar.setTime(ISO_DATE_FORMAT.parse(dateStr));
+            return calendar;
+        } catch (ParseException e) {
+            logger.warning("Failed to parse datetime: " + dateStr);
+            throw ApiException.invalidArgument("Invalid datetime format: " + dateStr + ". Expected ISO 8601 format (e.g., 2024-01-15T10:30:00Z)");
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<GregorianCalendar> convertToCalendarList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<GregorianCalendar> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToCalendar(item));
+            }
+            return result;
+        }
+        return List.of(convertToCalendar(value));
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/ObjectResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/ObjectResource.java
@@ -1,0 +1,1153 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+import jp.aegif.nemaki.api.v1.model.response.AllowableActionsResponse;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.ObjectListResponse;
+import jp.aegif.nemaki.api.v1.model.response.ObjectResponse;
+import jp.aegif.nemaki.cmis.service.NavigationService;
+import jp.aegif.nemaki.cmis.service.ObjectService;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.PropertyIds;
+import org.apache.chemistry.opencmis.commons.data.AllowableActions;
+import org.apache.chemistry.opencmis.commons.data.ContentStream;
+import org.apache.chemistry.opencmis.commons.data.ObjectData;
+import org.apache.chemistry.opencmis.commons.data.ObjectParentData;
+import org.apache.chemistry.opencmis.commons.data.Properties;
+import org.apache.chemistry.opencmis.commons.data.PropertyData;
+import org.apache.chemistry.opencmis.commons.enums.Action;
+import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.ContentStreamImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertiesImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyBooleanImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDateTimeImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDecimalImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyHtmlImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIdImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIntegerImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyStringImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyUriImpl;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.apache.chemistry.opencmis.commons.spi.Holder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/objects")
+@Tag(name = "objects", description = "CMIS object operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class ObjectResource {
+    
+    private static final Logger logger = Logger.getLogger(ObjectResource.class.getName());
+    private static final SimpleDateFormat ISO_DATE_FORMAT;
+    
+    static {
+        ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+    
+    @Autowired
+    private ObjectService objectService;
+    
+    @Autowired
+    private NavigationService navigationService;
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @GET
+    @Path("/{objectId}")
+    @Operation(
+            summary = "Get object",
+            description = "Gets the specified information for the object specified by ID"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Object information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getObject(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Include ACL")
+            @QueryParam("includeAcl") @DefaultValue("false") Boolean includeAcl) {
+        
+        logger.info("API v1: Getting object " + objectId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ObjectData objectData = objectService.getObject(
+                    callContext, repositoryId, objectId, filter,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, false, includeAcl, null);
+            
+            if (objectData == null) {
+                throw ApiException.objectNotFound(objectId, repositoryId);
+            }
+            
+            ObjectResponse response = mapToObjectResponse(objectData, repositoryId, includeAllowableActions);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting object " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get object: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/byPath")
+    @Operation(
+            summary = "Get object by path",
+            description = "Gets the specified information for the object specified by path"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Object information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getObjectByPath(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object path", required = true, example = "/invoices/2026/invoice-001.pdf")
+            @QueryParam("path") String path,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Include ACL")
+            @QueryParam("includeAcl") @DefaultValue("false") Boolean includeAcl) {
+        
+        logger.info("API v1: Getting object by path " + path + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            
+            if (path == null || path.isEmpty()) {
+                throw ApiException.invalidArgument("Path parameter is required");
+            }
+            
+            CallContext callContext = getCallContext();
+            
+            ObjectData objectData = objectService.getObjectByPath(
+                    callContext, repositoryId, path, filter,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, false, includeAcl, null);
+            
+            if (objectData == null) {
+                throw ApiException.objectNotFound("path:" + path, repositoryId);
+            }
+            
+            ObjectResponse response = mapToObjectResponse(objectData, repositoryId, includeAllowableActions);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting object by path " + path + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get object by path: " + e.getMessage(), e);
+        }
+    }
+    
+    @DELETE
+    @Path("/{objectId}")
+    @Operation(
+            summary = "Delete object",
+            description = "Deletes the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Object deleted successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Permission denied",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response deleteObject(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Delete all versions")
+            @QueryParam("allVersions") @DefaultValue("true") Boolean allVersions) {
+        
+        logger.info("API v1: Deleting object " + objectId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            objectService.deleteObject(callContext, repositoryId, objectId, allVersions, null);
+            
+            return Response.noContent().build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error deleting object " + objectId + ": " + e.getMessage());
+            if (e.getMessage() != null && e.getMessage().contains("not found")) {
+                throw ApiException.objectNotFound(objectId, repositoryId);
+            }
+            throw ApiException.internalError("Failed to delete object: " + e.getMessage(), e);
+        }
+    }
+    
+    @PUT
+    @Path("/{objectId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Update object properties",
+            description = "Updates the properties of the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Object updated successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response updateProperties(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Change token for optimistic locking")
+            @QueryParam("changeToken") String changeToken,
+            Map<String, PropertyValue> properties) {
+        
+        logger.info("API v1: Updating properties for object " + objectId + " in repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Properties cmisProperties = convertToProperties(properties);
+            Holder<String> objectIdHolder = new Holder<>(objectId);
+            Holder<String> changeTokenHolder = changeToken != null ? new Holder<>(changeToken) : null;
+            
+            objectService.updateProperties(callContext, repositoryId, objectIdHolder, cmisProperties, changeTokenHolder, null);
+            
+            ObjectData updatedObject = objectService.getObject(
+                    callContext, repositoryId, objectIdHolder.getValue(), null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            ObjectResponse response = mapToObjectResponse(updatedObject, repositoryId, true);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error updating object " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to update object: " + e.getMessage(), e);
+        }
+    }
+    
+    @POST
+    @Path("/{objectId}/move")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Move object",
+            description = "Moves the specified object from one folder to another"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Object moved successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object or folder not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response moveObject(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Source folder ID", required = true)
+            @QueryParam("sourceFolderId") String sourceFolderId,
+            @Parameter(description = "Target folder ID", required = true)
+            @QueryParam("targetFolderId") String targetFolderId) {
+        
+        logger.info("API v1: Moving object " + objectId + " from " + sourceFolderId + " to " + targetFolderId);
+        
+        try {
+            validateRepository(repositoryId);
+            
+            if (sourceFolderId == null || sourceFolderId.isEmpty()) {
+                throw ApiException.invalidArgument("sourceFolderId is required");
+            }
+            if (targetFolderId == null || targetFolderId.isEmpty()) {
+                throw ApiException.invalidArgument("targetFolderId is required");
+            }
+            
+            CallContext callContext = getCallContext();
+            Holder<String> objectIdHolder = new Holder<>(objectId);
+            
+            objectService.moveObject(callContext, repositoryId, objectIdHolder, sourceFolderId, targetFolderId, null);
+            
+            ObjectData movedObject = objectService.getObject(
+                    callContext, repositoryId, objectIdHolder.getValue(), null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            ObjectResponse response = mapToObjectResponse(movedObject, repositoryId, true);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error moving object " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to move object: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{objectId}/allowableActions")
+    @Operation(
+            summary = "Get allowable actions",
+            description = "Gets the list of allowable actions for the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Allowable actions",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AllowableActionsResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getAllowableActions(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId) {
+        
+        logger.info("API v1: Getting allowable actions for object " + objectId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            AllowableActions allowableActions = objectService.getAllowableActions(callContext, repositoryId, objectId);
+            
+            if (allowableActions == null) {
+                throw ApiException.objectNotFound(objectId, repositoryId);
+            }
+            
+            AllowableActionsResponse response = mapAllowableActions(allowableActions);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting allowable actions for " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get allowable actions: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{objectId}/content")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Operation(
+            summary = "Get content stream",
+            description = "Gets the content stream for the specified document object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Content stream",
+                    content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object or content not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getContentStream(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Stream ID for renditions")
+            @QueryParam("streamId") String streamId,
+            @Parameter(description = "Offset in bytes")
+            @QueryParam("offset") BigInteger offset,
+            @Parameter(description = "Length in bytes")
+            @QueryParam("length") BigInteger length) {
+        
+        logger.info("API v1: Getting content stream for object " + objectId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ContentStream contentStream = objectService.getContentStream(
+                    callContext, repositoryId, objectId, streamId, offset, length);
+            
+            if (contentStream == null) {
+                throw ApiException.objectNotFound(objectId + " (content)", repositoryId);
+            }
+            
+            StreamingOutput streamingOutput = output -> {
+                try (InputStream input = contentStream.getStream()) {
+                    byte[] buffer = new byte[8192];
+                    int bytesRead;
+                    while ((bytesRead = input.read(buffer)) != -1) {
+                        output.write(buffer, 0, bytesRead);
+                    }
+                }
+            };
+            
+            Response.ResponseBuilder responseBuilder = Response.ok(streamingOutput);
+            
+            if (contentStream.getMimeType() != null) {
+                responseBuilder.type(contentStream.getMimeType());
+            }
+            if (contentStream.getFileName() != null) {
+                responseBuilder.header("Content-Disposition", 
+                        "attachment; filename=\"" + contentStream.getFileName() + "\"");
+            }
+                        if (contentStream.getLength() >= 0) {
+                            responseBuilder.header("Content-Length", contentStream.getLength());
+                        }
+            
+            return responseBuilder.build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting content stream for " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get content stream: " + e.getMessage(), e);
+        }
+    }
+    
+    @PUT
+    @Path("/{objectId}/content")
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    @Operation(
+            summary = "Set content stream",
+            description = "Sets the content stream for the specified document object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Content stream set successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response setContentStream(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Overwrite existing content")
+            @QueryParam("overwriteFlag") @DefaultValue("true") Boolean overwriteFlag,
+            @Parameter(description = "Change token for optimistic locking")
+            @QueryParam("changeToken") String changeToken,
+            @Parameter(description = "Content MIME type")
+            @QueryParam("mimeType") @DefaultValue("application/octet-stream") String mimeType,
+            @Parameter(description = "File name")
+            @QueryParam("fileName") String fileName,
+            InputStream contentInputStream) {
+        
+        logger.info("API v1: Setting content stream for object " + objectId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            ContentStream contentStream = new ContentStreamImpl(fileName, null, mimeType, contentInputStream);
+            
+            Holder<String> objectIdHolder = new Holder<>(objectId);
+            Holder<String> changeTokenHolder = changeToken != null ? new Holder<>(changeToken) : null;
+            
+            objectService.setContentStream(callContext, repositoryId, objectIdHolder, 
+                    overwriteFlag, contentStream, changeTokenHolder, null);
+            
+            ObjectData updatedObject = objectService.getObject(
+                    callContext, repositoryId, objectIdHolder.getValue(), null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            ObjectResponse response = mapToObjectResponse(updatedObject, repositoryId, true);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error setting content stream for " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to set content stream: " + e.getMessage(), e);
+        }
+    }
+    
+    @DELETE
+    @Path("/{objectId}/content")
+    @Operation(
+            summary = "Delete content stream",
+            description = "Deletes the content stream for the specified document object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Content stream deleted successfully",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response deleteContentStream(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Change token for optimistic locking")
+            @QueryParam("changeToken") String changeToken) {
+        
+        logger.info("API v1: Deleting content stream for object " + objectId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Holder<String> objectIdHolder = new Holder<>(objectId);
+            Holder<String> changeTokenHolder = changeToken != null ? new Holder<>(changeToken) : null;
+            
+            objectService.deleteContentStream(callContext, repositoryId, objectIdHolder, changeTokenHolder, null);
+            
+            ObjectData updatedObject = objectService.getObject(
+                    callContext, repositoryId, objectIdHolder.getValue(), null,
+                    true, IncludeRelationships.NONE, null, false, false, null);
+            
+            ObjectResponse response = mapToObjectResponse(updatedObject, repositoryId, true);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error deleting content stream for " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to delete content stream: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{objectId}/parents")
+    @Operation(
+            summary = "Get object parents",
+            description = "Gets the parent folder(s) for the specified non-folder, fileable object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of parent folders",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectListResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getObjectParents(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions) {
+        
+        logger.info("API v1: Getting parents for object " + objectId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            List<ObjectParentData> parents = navigationService.getObjectParents(
+                    callContext, repositoryId, objectId, filter,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, true, null);
+            
+            List<ObjectResponse> parentResponses = new ArrayList<>();
+            if (parents != null) {
+                for (ObjectParentData parent : parents) {
+                    if (parent.getObject() != null) {
+                        parentResponses.add(mapToObjectResponse(parent.getObject(), repositoryId, includeAllowableActions));
+                    }
+                }
+            }
+            
+            ObjectListResponse response = new ObjectListResponse();
+            response.setObjects(parentResponses);
+            response.setNumItems((long) parentResponses.size());
+            response.setHasMoreItems(false);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting parents for " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get object parents: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private ObjectResponse mapToObjectResponse(ObjectData objectData, String repositoryId, Boolean includeAllowableActions) {
+        ObjectResponse response = new ObjectResponse();
+        
+        Properties properties = objectData.getProperties();
+        if (properties != null) {
+            response.setObjectId(getStringProperty(properties, PropertyIds.OBJECT_ID));
+            response.setBaseTypeId(getStringProperty(properties, PropertyIds.BASE_TYPE_ID));
+            response.setObjectTypeId(getStringProperty(properties, PropertyIds.OBJECT_TYPE_ID));
+            response.setName(getStringProperty(properties, PropertyIds.NAME));
+            response.setDescription(getStringProperty(properties, PropertyIds.DESCRIPTION));
+            response.setCreatedBy(getStringProperty(properties, PropertyIds.CREATED_BY));
+            response.setCreationDate(getDateProperty(properties, PropertyIds.CREATION_DATE));
+            response.setLastModifiedBy(getStringProperty(properties, PropertyIds.LAST_MODIFIED_BY));
+            response.setLastModificationDate(getDateProperty(properties, PropertyIds.LAST_MODIFICATION_DATE));
+            response.setChangeToken(getStringProperty(properties, PropertyIds.CHANGE_TOKEN));
+            response.setParentId(getStringProperty(properties, PropertyIds.PARENT_ID));
+            response.setPath(getStringProperty(properties, PropertyIds.PATH));
+            
+            response.setIsLatestVersion(getBooleanProperty(properties, PropertyIds.IS_LATEST_VERSION));
+            response.setIsLatestMajorVersion(getBooleanProperty(properties, PropertyIds.IS_LATEST_MAJOR_VERSION));
+            response.setIsMajorVersion(getBooleanProperty(properties, PropertyIds.IS_MAJOR_VERSION));
+            response.setVersionLabel(getStringProperty(properties, PropertyIds.VERSION_LABEL));
+            response.setVersionSeriesId(getStringProperty(properties, PropertyIds.VERSION_SERIES_ID));
+            response.setIsVersionSeriesCheckedOut(getBooleanProperty(properties, PropertyIds.IS_VERSION_SERIES_CHECKED_OUT));
+            response.setVersionSeriesCheckedOutBy(getStringProperty(properties, PropertyIds.VERSION_SERIES_CHECKED_OUT_BY));
+            response.setVersionSeriesCheckedOutId(getStringProperty(properties, PropertyIds.VERSION_SERIES_CHECKED_OUT_ID));
+            response.setCheckinComment(getStringProperty(properties, PropertyIds.CHECKIN_COMMENT));
+            
+            response.setContentStreamLength(getLongProperty(properties, PropertyIds.CONTENT_STREAM_LENGTH));
+            response.setContentStreamMimeType(getStringProperty(properties, PropertyIds.CONTENT_STREAM_MIME_TYPE));
+            response.setContentStreamFileName(getStringProperty(properties, PropertyIds.CONTENT_STREAM_FILE_NAME));
+            response.setContentStreamId(getStringProperty(properties, PropertyIds.CONTENT_STREAM_ID));
+            
+            response.setIsImmutable(getBooleanProperty(properties, PropertyIds.IS_IMMUTABLE));
+            response.setSecondaryTypeIds(getMultiStringProperty(properties, PropertyIds.SECONDARY_OBJECT_TYPE_IDS));
+            
+            Map<String, PropertyValue> propertyMap = new HashMap<>();
+            for (PropertyData<?> prop : properties.getPropertyList()) {
+                propertyMap.put(prop.getId(), mapPropertyValue(prop));
+            }
+            response.setProperties(propertyMap);
+        }
+        
+        if (includeAllowableActions != null && includeAllowableActions && objectData.getAllowableActions() != null) {
+            response.setAllowableActions(mapAllowableActions(objectData.getAllowableActions()));
+        }
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        String objectId = response.getObjectId();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId));
+        links.put("allowableActions", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId + "/allowableActions"));
+        links.put("parents", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId + "/parents"));
+        
+        if ("cmis:document".equals(response.getBaseTypeId())) {
+            links.put("content", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId + "/content"));
+            links.put("versions", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/documents/" + objectId + "/versions"));
+        }
+        if ("cmis:folder".equals(response.getBaseTypeId())) {
+            links.put("children", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + objectId + "/children"));
+            links.put("descendants", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + objectId + "/descendants"));
+        }
+        
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private String getStringProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            return prop.getFirstValue().toString();
+        }
+        return null;
+    }
+    
+    private Boolean getBooleanProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof Boolean) {
+            return (Boolean) prop.getFirstValue();
+        }
+        return null;
+    }
+    
+    private Long getLongProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            Object value = prop.getFirstValue();
+            if (value instanceof Long) {
+                return (Long) value;
+            } else if (value instanceof BigInteger) {
+                return ((BigInteger) value).longValue();
+            } else if (value instanceof Number) {
+                return ((Number) value).longValue();
+            }
+        }
+        return null;
+    }
+    
+    private String getDateProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                return ISO_DATE_FORMAT.format(cal.getTime());
+            }
+        }
+        return null;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<String> getMultiStringProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getValues() != null) {
+            List<String> result = new ArrayList<>();
+            for (Object value : prop.getValues()) {
+                if (value != null) {
+                    result.add(value.toString());
+                }
+            }
+            return result.isEmpty() ? null : result;
+        }
+        return null;
+    }
+    
+    private PropertyValue mapPropertyValue(PropertyData<?> prop) {
+        Object value = prop.getValues() != null && prop.getValues().size() > 1 
+                ? prop.getValues() 
+                : prop.getFirstValue();
+        
+        String type = "string";
+        if (prop.getFirstValue() instanceof Boolean) {
+            type = "boolean";
+        } else if (prop.getFirstValue() instanceof Long || prop.getFirstValue() instanceof Integer || prop.getFirstValue() instanceof BigInteger) {
+            type = "integer";
+        } else if (prop.getFirstValue() instanceof Double || prop.getFirstValue() instanceof Float || prop.getFirstValue() instanceof BigDecimal) {
+            type = "decimal";
+        } else if (prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                value = ISO_DATE_FORMAT.format(cal.getTime());
+            }
+            type = "datetime";
+        }
+        
+        PropertyValue pv = new PropertyValue(value, type);
+        pv.setPropertyDefinitionId(prop.getId());
+        pv.setLocalName(prop.getLocalName());
+        pv.setDisplayName(prop.getDisplayName());
+        pv.setQueryName(prop.getQueryName());
+        
+        return pv;
+    }
+    
+    private AllowableActionsResponse mapAllowableActions(AllowableActions allowableActions) {
+        AllowableActionsResponse response = new AllowableActionsResponse();
+        Set<Action> actions = allowableActions.getAllowableActions();
+        if (actions == null) {
+            actions = Collections.emptySet();
+        }
+        
+        response.setCanDeleteObject(actions.contains(Action.CAN_DELETE_OBJECT));
+        response.setCanUpdateProperties(actions.contains(Action.CAN_UPDATE_PROPERTIES));
+        response.setCanGetFolderTree(actions.contains(Action.CAN_GET_FOLDER_TREE));
+        response.setCanGetProperties(actions.contains(Action.CAN_GET_PROPERTIES));
+        response.setCanGetObjectRelationships(actions.contains(Action.CAN_GET_OBJECT_RELATIONSHIPS));
+        response.setCanGetObjectParents(actions.contains(Action.CAN_GET_OBJECT_PARENTS));
+        response.setCanGetFolderParent(actions.contains(Action.CAN_GET_FOLDER_PARENT));
+        response.setCanGetDescendants(actions.contains(Action.CAN_GET_DESCENDANTS));
+        response.setCanMoveObject(actions.contains(Action.CAN_MOVE_OBJECT));
+        response.setCanDeleteContentStream(actions.contains(Action.CAN_DELETE_CONTENT_STREAM));
+        response.setCanCheckOut(actions.contains(Action.CAN_CHECK_OUT));
+        response.setCanCancelCheckOut(actions.contains(Action.CAN_CANCEL_CHECK_OUT));
+        response.setCanCheckIn(actions.contains(Action.CAN_CHECK_IN));
+        response.setCanSetContentStream(actions.contains(Action.CAN_SET_CONTENT_STREAM));
+        response.setCanGetAllVersions(actions.contains(Action.CAN_GET_ALL_VERSIONS));
+        response.setCanAddObjectToFolder(actions.contains(Action.CAN_ADD_OBJECT_TO_FOLDER));
+        response.setCanRemoveObjectFromFolder(actions.contains(Action.CAN_REMOVE_OBJECT_FROM_FOLDER));
+        response.setCanGetContentStream(actions.contains(Action.CAN_GET_CONTENT_STREAM));
+        response.setCanApplyPolicy(actions.contains(Action.CAN_APPLY_POLICY));
+        response.setCanGetAppliedPolicies(actions.contains(Action.CAN_GET_APPLIED_POLICIES));
+        response.setCanRemovePolicy(actions.contains(Action.CAN_REMOVE_POLICY));
+        response.setCanGetChildren(actions.contains(Action.CAN_GET_CHILDREN));
+        response.setCanCreateDocument(actions.contains(Action.CAN_CREATE_DOCUMENT));
+        response.setCanCreateFolder(actions.contains(Action.CAN_CREATE_FOLDER));
+        response.setCanCreateRelationship(actions.contains(Action.CAN_CREATE_RELATIONSHIP));
+        response.setCanDeleteTree(actions.contains(Action.CAN_DELETE_TREE));
+        response.setCanGetRenditions(actions.contains(Action.CAN_GET_RENDITIONS));
+        response.setCanGetAcl(actions.contains(Action.CAN_GET_ACL));
+        response.setCanApplyAcl(actions.contains(Action.CAN_APPLY_ACL));
+        
+        return response;
+    }
+    
+    private Properties convertToProperties(Map<String, PropertyValue> propertyMap) {
+        PropertiesImpl properties = new PropertiesImpl();
+        
+        if (propertyMap != null) {
+            for (Map.Entry<String, PropertyValue> entry : propertyMap.entrySet()) {
+                String propertyId = entry.getKey();
+                PropertyValue pv = entry.getValue();
+                
+                if (pv == null || pv.getValue() == null) {
+                    continue;
+                }
+                
+                String type = pv.getType() != null ? pv.getType() : "string";
+                Object value = pv.getValue();
+                boolean isMultiValued = "multi".equals(pv.getCardinality()) || value instanceof List;
+                
+                switch (type) {
+                    case "id":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyIdImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyIdImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "boolean":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBooleanList(value)));
+                        } else {
+                            properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBoolean(value)));
+                        }
+                        break;
+                    case "integer":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigIntegerList(value)));
+                        } else {
+                            properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigInteger(value)));
+                        }
+                        break;
+                    case "decimal":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimalList(value)));
+                        } else {
+                            properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimal(value)));
+                        }
+                        break;
+                    case "datetime":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendarList(value)));
+                        } else {
+                            properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendar(value)));
+                        }
+                        break;
+                    case "html":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyHtmlImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyHtmlImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "uri":
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyUriImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyUriImpl(propertyId, value.toString()));
+                        }
+                        break;
+                    case "string":
+                    default:
+                        if (isMultiValued) {
+                            properties.addProperty(new PropertyStringImpl(propertyId, convertToStringList(value)));
+                        } else {
+                            properties.addProperty(new PropertyStringImpl(propertyId, value.toString()));
+                        }
+                        break;
+                }
+            }
+        }
+        
+        return properties;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<String> convertToStringList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<String> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(item != null ? item.toString() : null);
+            }
+            return result;
+        }
+        return List.of(value.toString());
+    }
+    
+    private Boolean convertToBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<Boolean> convertToBooleanList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<Boolean> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBoolean(item));
+            }
+            return result;
+        }
+        return List.of(convertToBoolean(value));
+    }
+    
+    private BigInteger convertToBigInteger(Object value) {
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof Number) {
+            return BigInteger.valueOf(((Number) value).longValue());
+        }
+        return new BigInteger(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<BigInteger> convertToBigIntegerList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigInteger> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigInteger(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigInteger(value));
+    }
+    
+    private BigDecimal convertToBigDecimal(Object value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<BigDecimal> convertToBigDecimalList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigDecimal> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigDecimal(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigDecimal(value));
+    }
+    
+    private GregorianCalendar convertToCalendar(Object value) {
+        if (value instanceof GregorianCalendar) {
+            return (GregorianCalendar) value;
+        }
+        String dateStr = value.toString();
+        try {
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+            calendar.setTime(ISO_DATE_FORMAT.parse(dateStr));
+            return calendar;
+        } catch (ParseException e) {
+            logger.warning("Failed to parse datetime: " + dateStr);
+            throw ApiException.invalidArgument("Invalid datetime format: " + dateStr + ". Expected ISO 8601 format (e.g., 2024-01-15T10:30:00Z)");
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<GregorianCalendar> convertToCalendarList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<GregorianCalendar> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToCalendar(item));
+            }
+            return result;
+        }
+        return List.of(convertToCalendar(value));
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/PolicyResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/PolicyResource.java
@@ -1,0 +1,676 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+import jp.aegif.nemaki.api.v1.model.request.PolicyApplyRequest;
+import jp.aegif.nemaki.api.v1.model.request.PolicyCreateRequest;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.ObjectResponse;
+import jp.aegif.nemaki.api.v1.model.response.PolicyListResponse;
+import jp.aegif.nemaki.cmis.service.ObjectService;
+import jp.aegif.nemaki.cmis.service.PolicyService;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.PropertyIds;
+import org.apache.chemistry.opencmis.commons.data.ObjectData;
+import org.apache.chemistry.opencmis.commons.data.Properties;
+import org.apache.chemistry.opencmis.commons.data.PropertyData;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertiesImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyBooleanImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDateTimeImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDecimalImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyHtmlImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIdImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIntegerImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyStringImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyUriImpl;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/policies")
+@Tag(name = "policies", description = "CMIS policy operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class PolicyResource {
+    
+    private static final Logger logger = Logger.getLogger(PolicyResource.class.getName());
+    private static final SimpleDateFormat ISO_DATE_FORMAT;
+    
+    static {
+        ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+    
+    @Autowired
+    private PolicyService policyService;
+    
+    @Autowired
+    private ObjectService objectService;
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Create policy",
+            description = "Creates a policy object of the specified type"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Policy created",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response createPolicy(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Policy to create", required = true)
+            PolicyCreateRequest request) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            if (request == null) {
+                throw ApiException.invalidArgument("Request body is required");
+            }
+            if (request.getName() == null || request.getName().isEmpty()) {
+                throw ApiException.invalidArgument("Policy name is required");
+            }
+            
+            Properties properties = convertToProperties(request);
+            
+            String policyId = objectService.createPolicy(
+                    callContext, repositoryId, properties, request.getFolderId(), 
+                    null, null, null, null);
+            
+            ObjectData policyData = objectService.getObject(
+                    callContext, repositoryId, policyId, null, Boolean.FALSE, 
+                    null, null, Boolean.FALSE, Boolean.FALSE, null);
+            
+            ObjectResponse response = mapToObjectResponse(policyData, repositoryId);
+            
+            return Response.status(Response.Status.CREATED).entity(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error creating policy: " + e.getMessage());
+            throw ApiException.internalError("Failed to create policy: " + e.getMessage(), e);
+        }
+    }
+    
+    @POST
+    @Path("/apply")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Apply policy",
+            description = "Applies a policy to the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Policy applied successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Policy or object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response applyPolicy(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Policy apply request", required = true)
+            PolicyApplyRequest request) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            if (request == null) {
+                throw ApiException.invalidArgument("Request body is required");
+            }
+            if (request.getPolicyId() == null || request.getPolicyId().isEmpty()) {
+                throw ApiException.invalidArgument("Policy ID (policyId) is required");
+            }
+            if (request.getObjectId() == null || request.getObjectId().isEmpty()) {
+                throw ApiException.invalidArgument("Object ID (objectId) is required");
+            }
+            
+            policyService.applyPolicy(callContext, repositoryId, request.getPolicyId(), request.getObjectId(), null);
+            
+            Map<String, Object> result = new HashMap<>();
+            result.put("success", true);
+            result.put("policyId", request.getPolicyId());
+            result.put("objectId", request.getObjectId());
+            result.put("message", "Policy applied successfully");
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("policy", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + request.getPolicyId()));
+            links.put("object", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + request.getObjectId()));
+            links.put("appliedPolicies", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/policies/object/" + request.getObjectId()));
+            result.put("_links", links);
+            
+            return Response.ok(result).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error applying policy: " + e.getMessage());
+            throw ApiException.internalError("Failed to apply policy: " + e.getMessage(), e);
+        }
+    }
+    
+    @POST
+    @Path("/remove")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Remove policy",
+            description = "Removes a policy from the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Policy removed successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Policy or object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response removePolicy(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Policy remove request", required = true)
+            PolicyApplyRequest request) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            if (request == null) {
+                throw ApiException.invalidArgument("Request body is required");
+            }
+            if (request.getPolicyId() == null || request.getPolicyId().isEmpty()) {
+                throw ApiException.invalidArgument("Policy ID (policyId) is required");
+            }
+            if (request.getObjectId() == null || request.getObjectId().isEmpty()) {
+                throw ApiException.invalidArgument("Object ID (objectId) is required");
+            }
+            
+            policyService.removePolicy(callContext, repositoryId, request.getPolicyId(), request.getObjectId(), null);
+            
+            Map<String, Object> result = new HashMap<>();
+            result.put("success", true);
+            result.put("policyId", request.getPolicyId());
+            result.put("objectId", request.getObjectId());
+            result.put("message", "Policy removed successfully");
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("policy", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + request.getPolicyId()));
+            links.put("object", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + request.getObjectId()));
+            result.put("_links", links);
+            
+            return Response.ok(result).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error removing policy: " + e.getMessage());
+            throw ApiException.internalError("Failed to remove policy: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/object/{objectId}")
+    @Operation(
+            summary = "Get applied policies",
+            description = "Gets the list of policies currently applied to the specified object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of applied policies",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = PolicyListResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getAppliedPolicies(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Property filter")
+            @QueryParam("filter") String filter) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            List<ObjectData> policies = policyService.getAppliedPolicies(
+                    callContext, repositoryId, objectId, filter, null);
+            
+            PolicyListResponse response = mapToPolicyListResponse(policies, repositoryId, objectId);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting applied policies for object " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get applied policies: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (repositoryService.getRepositoryInfo(repositoryId) == null) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private Properties convertToProperties(PolicyCreateRequest request) {
+        PropertiesImpl properties = new PropertiesImpl();
+        
+        String typeId = request.getTypeId() != null ? request.getTypeId() : "cmis:policy";
+        properties.addProperty(new PropertyIdImpl(PropertyIds.OBJECT_TYPE_ID, typeId));
+        properties.addProperty(new PropertyStringImpl(PropertyIds.NAME, request.getName()));
+        
+        if (request.getDescription() != null) {
+            properties.addProperty(new PropertyStringImpl(PropertyIds.DESCRIPTION, request.getDescription()));
+        }
+        
+        if (request.getPolicyText() != null) {
+            properties.addProperty(new PropertyStringImpl(PropertyIds.POLICY_TEXT, request.getPolicyText()));
+        }
+        
+        addCustomProperties(properties, request.getProperties());
+        
+        return properties;
+    }
+
+    private void addCustomProperties(PropertiesImpl properties, Map<String, PropertyValue> propertyMap) {
+        if (propertyMap == null) {
+            return;
+        }
+
+        for (Map.Entry<String, PropertyValue> entry : propertyMap.entrySet()) {
+            String propertyId = entry.getKey();
+            PropertyValue pv = entry.getValue();
+
+            if (pv == null || pv.getValue() == null) {
+                continue;
+            }
+
+            String type = pv.getType() != null ? pv.getType() : "string";
+            Object value = pv.getValue();
+            boolean isMultiValued = "multi".equals(pv.getCardinality()) || value instanceof List;
+
+            switch (type) {
+                case "id":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyIdImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyIdImpl(propertyId, value.toString()));
+                    }
+                    break;
+                case "boolean":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBooleanList(value)));
+                    } else {
+                        properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBoolean(value)));
+                    }
+                    break;
+                case "integer":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigIntegerList(value)));
+                    } else {
+                        properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigInteger(value)));
+                    }
+                    break;
+                case "decimal":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimalList(value)));
+                    } else {
+                        properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimal(value)));
+                    }
+                    break;
+                case "datetime":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendarList(value)));
+                    } else {
+                        properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendar(value)));
+                    }
+                    break;
+                case "html":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyHtmlImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyHtmlImpl(propertyId, value.toString()));
+                    }
+                    break;
+                case "uri":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyUriImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyUriImpl(propertyId, value.toString()));
+                    }
+                    break;
+                case "string":
+                default:
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyStringImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyStringImpl(propertyId, value.toString()));
+                    }
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> convertToStringList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<String> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(item != null ? item.toString() : null);
+            }
+            return result;
+        }
+        return List.of(value.toString());
+    }
+
+    private Boolean convertToBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Boolean> convertToBooleanList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<Boolean> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBoolean(item));
+            }
+            return result;
+        }
+        return List.of(convertToBoolean(value));
+    }
+
+    private BigInteger convertToBigInteger(Object value) {
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof Number) {
+            return BigInteger.valueOf(((Number) value).longValue());
+        }
+        return new BigInteger(value.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<BigInteger> convertToBigIntegerList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigInteger> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigInteger(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigInteger(value));
+    }
+
+    private BigDecimal convertToBigDecimal(Object value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<BigDecimal> convertToBigDecimalList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigDecimal> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigDecimal(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigDecimal(value));
+    }
+
+    private GregorianCalendar convertToCalendar(Object value) {
+        if (value instanceof GregorianCalendar) {
+            return (GregorianCalendar) value;
+        }
+        String dateStr = value.toString();
+        try {
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+            synchronized (ISO_DATE_FORMAT) {
+                calendar.setTime(ISO_DATE_FORMAT.parse(dateStr));
+            }
+            return calendar;
+        } catch (ParseException e) {
+            logger.warning("Failed to parse datetime: " + dateStr);
+            throw ApiException.invalidArgument("Invalid datetime format: " + dateStr + ". Expected ISO 8601 format (e.g., 2024-01-15T10:30:00Z)");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<GregorianCalendar> convertToCalendarList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<GregorianCalendar> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToCalendar(item));
+            }
+            return result;
+        }
+        return List.of(convertToCalendar(value));
+    }
+    
+    private PolicyListResponse mapToPolicyListResponse(List<ObjectData> policies, String repositoryId, String objectId) {
+        PolicyListResponse response = new PolicyListResponse();
+        response.setObjectId(objectId);
+        
+        List<ObjectResponse> items = new ArrayList<>();
+        if (policies != null) {
+            for (ObjectData policy : policies) {
+                items.add(mapToObjectResponse(policy, repositoryId));
+            }
+        }
+        response.setPolicies(items);
+        response.setNumPolicies(items.size());
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/policies/object/" + objectId));
+        links.put("object", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId));
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private ObjectResponse mapToObjectResponse(ObjectData objectData, String repositoryId) {
+        ObjectResponse response = new ObjectResponse();
+        
+        Properties properties = objectData.getProperties();
+        if (properties != null) {
+            response.setObjectId(getStringProperty(properties, PropertyIds.OBJECT_ID));
+            response.setObjectTypeId(getStringProperty(properties, PropertyIds.OBJECT_TYPE_ID));
+            response.setBaseTypeId(getStringProperty(properties, PropertyIds.BASE_TYPE_ID));
+            response.setName(getStringProperty(properties, PropertyIds.NAME));
+            response.setDescription(getStringProperty(properties, PropertyIds.DESCRIPTION));
+            response.setCreatedBy(getStringProperty(properties, PropertyIds.CREATED_BY));
+            response.setCreationDate(getDateProperty(properties, PropertyIds.CREATION_DATE));
+            response.setLastModifiedBy(getStringProperty(properties, PropertyIds.LAST_MODIFIED_BY));
+            response.setLastModificationDate(getDateProperty(properties, PropertyIds.LAST_MODIFICATION_DATE));
+            
+            Map<String, PropertyValue> propertyMap = new HashMap<>();
+            for (PropertyData<?> prop : properties.getPropertyList()) {
+                propertyMap.put(prop.getId(), mapPropertyValue(prop));
+            }
+            response.setProperties(propertyMap);
+        }
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        String objectId = response.getObjectId();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId));
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private String getStringProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            return prop.getFirstValue().toString();
+        }
+        return null;
+    }
+    
+    private String getDateProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                return ISO_DATE_FORMAT.format(cal.getTime());
+            }
+        }
+        return null;
+    }
+    
+    private PropertyValue mapPropertyValue(PropertyData<?> prop) {
+        Object value = prop.getValues() != null && prop.getValues().size() > 1 
+                ? prop.getValues() 
+                : prop.getFirstValue();
+        
+        String type = "string";
+        if (prop.getFirstValue() instanceof Boolean) {
+            type = "boolean";
+        } else if (prop.getFirstValue() instanceof Long || prop.getFirstValue() instanceof Integer || prop.getFirstValue() instanceof BigInteger) {
+            type = "integer";
+        } else if (prop.getFirstValue() instanceof Double || prop.getFirstValue() instanceof Float || prop.getFirstValue() instanceof BigDecimal) {
+            type = "decimal";
+        } else if (prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                value = ISO_DATE_FORMAT.format(cal.getTime());
+            }
+            type = "datetime";
+        }
+        
+        PropertyValue pv = new PropertyValue(value, type);
+        pv.setPropertyDefinitionId(prop.getId());
+        pv.setLocalName(prop.getLocalName());
+        pv.setDisplayName(prop.getDisplayName());
+        pv.setQueryName(prop.getQueryName());
+        
+        return pv;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/QueryResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/QueryResource.java
@@ -1,0 +1,457 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.ObjectListResponse;
+import jp.aegif.nemaki.api.v1.model.response.ObjectResponse;
+import jp.aegif.nemaki.cmis.service.DiscoveryService;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.PropertyIds;
+import org.apache.chemistry.opencmis.commons.data.ObjectData;
+import org.apache.chemistry.opencmis.commons.data.ObjectList;
+import org.apache.chemistry.opencmis.commons.data.Properties;
+import org.apache.chemistry.opencmis.commons.data.PropertyData;
+import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.apache.chemistry.opencmis.commons.spi.Holder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/query")
+@Tag(name = "query", description = "CMIS query and discovery operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class QueryResource {
+    
+    private static final Logger logger = Logger.getLogger(QueryResource.class.getName());
+    private static final SimpleDateFormat ISO_DATE_FORMAT;
+    
+    static {
+        ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+    
+    @Autowired
+    private DiscoveryService discoveryService;
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Execute CMIS query",
+            description = "Executes a CMIS query statement against the contents of the repository"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Query results",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectListResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid query",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response query(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Search all versions")
+            @QueryParam("searchAllVersions") @DefaultValue("false") Boolean searchAllVersions,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems,
+            @Parameter(description = "Number of items to skip")
+            @QueryParam("skipCount") @DefaultValue("0") Integer skipCount,
+            Map<String, Object> requestBody) {
+        
+        logger.info("API v1: Executing query in repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            String statement = null;
+            if (requestBody != null && requestBody.containsKey("statement")) {
+                statement = (String) requestBody.get("statement");
+            }
+            
+            if (statement == null || statement.trim().isEmpty()) {
+                throw ApiException.invalidArgument("Query statement is required");
+            }
+            
+            ObjectList results = discoveryService.query(
+                    callContext, repositoryId, statement, searchAllVersions,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, BigInteger.valueOf(maxItems), BigInteger.valueOf(skipCount), null);
+            
+            List<ObjectResponse> objectResponses = new ArrayList<>();
+            if (results != null && results.getObjects() != null) {
+                for (ObjectData obj : results.getObjects()) {
+                    objectResponses.add(mapToObjectResponse(obj, repositoryId, includeAllowableActions));
+                }
+            }
+            
+            ObjectListResponse response = new ObjectListResponse();
+            response.setObjects(objectResponses);
+            response.setNumItems(results != null && results.getNumItems() != null 
+                    ? results.getNumItems().longValue() : (long) objectResponses.size());
+            response.setHasMoreItems(results != null && results.hasMoreItems() != null 
+                    ? results.hasMoreItems() : false);
+            response.setSkipCount((long) skipCount);
+            response.setMaxItems((long) maxItems);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/query"));
+            response.setLinks(links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error executing query: " + e.getMessage());
+            if (e.getMessage() != null && (e.getMessage().contains("parse") || e.getMessage().contains("syntax"))) {
+                throw ApiException.invalidArgument("Invalid query syntax: " + e.getMessage());
+            }
+            throw ApiException.internalError("Failed to execute query: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Operation(
+            summary = "Execute CMIS query (GET)",
+            description = "Executes a CMIS query statement against the contents of the repository using GET method"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Query results",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectListResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid query",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response queryGet(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "CMIS query statement", required = true, example = "SELECT * FROM cmis:document")
+            @QueryParam("statement") String statement,
+            @Parameter(description = "Search all versions")
+            @QueryParam("searchAllVersions") @DefaultValue("false") Boolean searchAllVersions,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems,
+            @Parameter(description = "Number of items to skip")
+            @QueryParam("skipCount") @DefaultValue("0") Integer skipCount) {
+        
+        logger.info("API v1: Executing query (GET) in repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            if (statement == null || statement.trim().isEmpty()) {
+                throw ApiException.invalidArgument("Query statement is required");
+            }
+            
+            ObjectList results = discoveryService.query(
+                    callContext, repositoryId, statement, searchAllVersions,
+                    includeAllowableActions, IncludeRelationships.NONE,
+                    null, BigInteger.valueOf(maxItems), BigInteger.valueOf(skipCount), null);
+            
+            List<ObjectResponse> objectResponses = new ArrayList<>();
+            if (results != null && results.getObjects() != null) {
+                for (ObjectData obj : results.getObjects()) {
+                    objectResponses.add(mapToObjectResponse(obj, repositoryId, includeAllowableActions));
+                }
+            }
+            
+            ObjectListResponse response = new ObjectListResponse();
+            response.setObjects(objectResponses);
+            response.setNumItems(results != null && results.getNumItems() != null 
+                    ? results.getNumItems().longValue() : (long) objectResponses.size());
+            response.setHasMoreItems(results != null && results.hasMoreItems() != null 
+                    ? results.hasMoreItems() : false);
+            response.setSkipCount((long) skipCount);
+            response.setMaxItems((long) maxItems);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/query?statement=" + java.net.URLEncoder.encode(statement, "UTF-8") + "&maxItems=" + maxItems + "&skipCount=" + skipCount));
+            
+            if (response.getHasMoreItems()) {
+                int nextSkip = skipCount + maxItems;
+                links.put("next", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/query?statement=" + java.net.URLEncoder.encode(statement, "UTF-8") + "&maxItems=" + maxItems + "&skipCount=" + nextSkip));
+            }
+            if (skipCount > 0) {
+                int prevSkip = Math.max(0, skipCount - maxItems);
+                links.put("prev", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/query?statement=" + java.net.URLEncoder.encode(statement, "UTF-8") + "&maxItems=" + maxItems + "&skipCount=" + prevSkip));
+            }
+            
+            response.setLinks(links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error executing query: " + e.getMessage());
+            if (e.getMessage() != null && (e.getMessage().contains("parse") || e.getMessage().contains("syntax"))) {
+                throw ApiException.invalidArgument("Invalid query syntax: " + e.getMessage());
+            }
+            throw ApiException.internalError("Failed to execute query: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/changes")
+    @Operation(
+            summary = "Get content changes",
+            description = "Gets the list of objects that have changed since a given point in the past"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Content changes",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            )
+    })
+    public Response getContentChanges(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Change log token (null for first call)")
+            @QueryParam("changeLogToken") String changeLogToken,
+            @Parameter(description = "Include properties")
+            @QueryParam("includeProperties") @DefaultValue("false") Boolean includeProperties,
+            @Parameter(description = "Property filter (comma-separated property IDs)")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include policy IDs")
+            @QueryParam("includePolicyIds") @DefaultValue("false") Boolean includePolicyIds,
+            @Parameter(description = "Include ACL")
+            @QueryParam("includeAcl") @DefaultValue("false") Boolean includeAcl,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems) {
+        
+        logger.info("API v1: Getting content changes for repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            Holder<String> changeLogTokenHolder = new Holder<>(changeLogToken);
+            
+            ObjectList changes = discoveryService.getContentChanges(
+                    callContext, repositoryId, changeLogTokenHolder,
+                    includeProperties, filter, includePolicyIds, includeAcl,
+                    BigInteger.valueOf(maxItems), null);
+            
+            List<Map<String, Object>> changeEntries = new ArrayList<>();
+            if (changes != null && changes.getObjects() != null) {
+                for (ObjectData obj : changes.getObjects()) {
+                    Map<String, Object> entry = new HashMap<>();
+                    entry.put("object", mapToObjectResponse(obj, repositoryId, false));
+                    if (obj.getChangeEventInfo() != null) {
+                        Map<String, Object> changeInfo = new HashMap<>();
+                        changeInfo.put("changeType", obj.getChangeEventInfo().getChangeType() != null 
+                                ? obj.getChangeEventInfo().getChangeType().value() : null);
+                        changeInfo.put("changeTime", obj.getChangeEventInfo().getChangeTime() != null 
+                                ? formatDate(obj.getChangeEventInfo().getChangeTime()) : null);
+                        entry.put("changeEventInfo", changeInfo);
+                    }
+                    changeEntries.add(entry);
+                }
+            }
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("changes", changeEntries);
+            response.put("changeLogToken", changeLogTokenHolder.getValue());
+            response.put("numItems", changes != null && changes.getNumItems() != null 
+                    ? changes.getNumItems().longValue() : (long) changeEntries.size());
+            response.put("hasMoreItems", changes != null && changes.hasMoreItems() != null 
+                    ? changes.hasMoreItems() : false);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/query/changes"));
+            
+            if (changeLogTokenHolder.getValue() != null) {
+                links.put("next", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/query/changes?changeLogToken=" + changeLogTokenHolder.getValue() + "&maxItems=" + maxItems));
+            }
+            
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting content changes: " + e.getMessage());
+            throw ApiException.internalError("Failed to get content changes: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private String formatDate(GregorianCalendar cal) {
+        if (cal == null) return null;
+        synchronized (ISO_DATE_FORMAT) {
+            return ISO_DATE_FORMAT.format(cal.getTime());
+        }
+    }
+    
+    private ObjectResponse mapToObjectResponse(ObjectData objectData, String repositoryId, Boolean includeAllowableActions) {
+        ObjectResponse response = new ObjectResponse();
+        
+        Properties properties = objectData.getProperties();
+        if (properties != null) {
+            response.setObjectId(getStringProperty(properties, PropertyIds.OBJECT_ID));
+            response.setBaseTypeId(getStringProperty(properties, PropertyIds.BASE_TYPE_ID));
+            response.setObjectTypeId(getStringProperty(properties, PropertyIds.OBJECT_TYPE_ID));
+            response.setName(getStringProperty(properties, PropertyIds.NAME));
+            response.setDescription(getStringProperty(properties, PropertyIds.DESCRIPTION));
+            response.setCreatedBy(getStringProperty(properties, PropertyIds.CREATED_BY));
+            response.setCreationDate(getDateProperty(properties, PropertyIds.CREATION_DATE));
+            response.setLastModifiedBy(getStringProperty(properties, PropertyIds.LAST_MODIFIED_BY));
+            response.setLastModificationDate(getDateProperty(properties, PropertyIds.LAST_MODIFICATION_DATE));
+            response.setChangeToken(getStringProperty(properties, PropertyIds.CHANGE_TOKEN));
+            
+            Map<String, PropertyValue> propertyMap = new HashMap<>();
+            for (PropertyData<?> prop : properties.getPropertyList()) {
+                propertyMap.put(prop.getId(), mapPropertyValue(prop));
+            }
+            response.setProperties(propertyMap);
+        }
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        String objectId = response.getObjectId();
+        if (objectId != null) {
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId));
+            response.setLinks(links);
+        }
+        
+        return response;
+    }
+    
+    private String getStringProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            return prop.getFirstValue().toString();
+        }
+        return null;
+    }
+    
+    private String getDateProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                return ISO_DATE_FORMAT.format(cal.getTime());
+            }
+        }
+        return null;
+    }
+    
+    private PropertyValue mapPropertyValue(PropertyData<?> prop) {
+        Object value = prop.getValues() != null && prop.getValues().size() > 1 
+                ? prop.getValues() 
+                : prop.getFirstValue();
+        
+        String type = "string";
+        if (prop.getFirstValue() instanceof Boolean) {
+            type = "boolean";
+        } else if (prop.getFirstValue() instanceof Long || prop.getFirstValue() instanceof Integer) {
+            type = "integer";
+        } else if (prop.getFirstValue() instanceof Double || prop.getFirstValue() instanceof Float) {
+            type = "decimal";
+        } else if (prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                value = ISO_DATE_FORMAT.format(cal.getTime());
+            }
+            type = "datetime";
+        }
+        
+        PropertyValue pv = new PropertyValue(value, type);
+        pv.setPropertyDefinitionId(prop.getId());
+        pv.setLocalName(prop.getLocalName());
+        pv.setDisplayName(prop.getDisplayName());
+        pv.setQueryName(prop.getQueryName());
+        
+        return pv;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/RelationshipResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/RelationshipResource.java
@@ -1,0 +1,596 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.PropertyValue;
+import jp.aegif.nemaki.api.v1.model.request.RelationshipRequest;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.ObjectListResponse;
+import jp.aegif.nemaki.api.v1.model.response.ObjectResponse;
+import jp.aegif.nemaki.api.v1.model.response.RelationshipResponse;
+import jp.aegif.nemaki.cmis.service.ObjectService;
+import jp.aegif.nemaki.cmis.service.RelationshipService;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.PropertyIds;
+import org.apache.chemistry.opencmis.commons.data.ObjectData;
+import org.apache.chemistry.opencmis.commons.data.ObjectList;
+import org.apache.chemistry.opencmis.commons.data.Properties;
+import org.apache.chemistry.opencmis.commons.data.PropertyData;
+import org.apache.chemistry.opencmis.commons.enums.RelationshipDirection;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertiesImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyBooleanImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDateTimeImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyDecimalImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyHtmlImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIdImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyIntegerImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyStringImpl;
+import org.apache.chemistry.opencmis.commons.impl.dataobjects.PropertyUriImpl;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/relationships")
+@Tag(name = "relationships", description = "CMIS relationship operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class RelationshipResource {
+    
+    private static final Logger logger = Logger.getLogger(RelationshipResource.class.getName());
+    private static final SimpleDateFormat ISO_DATE_FORMAT;
+    
+    static {
+        ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+    
+    @Autowired
+    private RelationshipService relationshipService;
+    
+    @Autowired
+    private ObjectService objectService;
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Create relationship",
+            description = "Creates a relationship object of the specified type"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Relationship created",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RelationshipResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response createRelationship(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Relationship to create", required = true)
+            RelationshipRequest request) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            if (request == null) {
+                throw ApiException.invalidArgument("Request body is required");
+            }
+            if (request.getSourceId() == null || request.getSourceId().isEmpty()) {
+                throw ApiException.invalidArgument("Source object ID (sourceId) is required");
+            }
+            if (request.getTargetId() == null || request.getTargetId().isEmpty()) {
+                throw ApiException.invalidArgument("Target object ID (targetId) is required");
+            }
+            
+            Properties properties = convertToProperties(request);
+            
+            String relationshipId = objectService.createRelationship(
+                    callContext, repositoryId, properties, null, null, null, null);
+            
+            ObjectData relationshipData = objectService.getObject(
+                    callContext, repositoryId, relationshipId, null, Boolean.FALSE, 
+                    null, null, Boolean.FALSE, Boolean.FALSE, null);
+            
+            RelationshipResponse response = mapToRelationshipResponse(relationshipData, repositoryId);
+            
+            return Response.status(Response.Status.CREATED).entity(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error creating relationship: " + e.getMessage());
+            throw ApiException.internalError("Failed to create relationship: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/object/{objectId}")
+    @Operation(
+            summary = "Get object relationships",
+            description = "Gets all or a subset of relationships associated with an independent object"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of relationships",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ObjectListResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Object not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getObjectRelationships(
+            @Parameter(description = "Repository ID", required = true)
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Object ID", required = true)
+            @PathParam("objectId") String objectId,
+            @Parameter(description = "Include relationships of subtypes")
+            @QueryParam("includeSubRelationshipTypes") @DefaultValue("false") Boolean includeSubRelationshipTypes,
+            @Parameter(description = "Relationship direction (source, target, either)")
+            @QueryParam("relationshipDirection") @DefaultValue("either") String relationshipDirection,
+            @Parameter(description = "Relationship type ID filter")
+            @QueryParam("typeId") String typeId,
+            @Parameter(description = "Property filter")
+            @QueryParam("filter") String filter,
+            @Parameter(description = "Include allowable actions")
+            @QueryParam("includeAllowableActions") @DefaultValue("false") Boolean includeAllowableActions,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems,
+            @Parameter(description = "Number of items to skip")
+            @QueryParam("skipCount") @DefaultValue("0") Integer skipCount) {
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            RelationshipDirection direction = parseRelationshipDirection(relationshipDirection);
+            
+            ObjectList relationships = relationshipService.getObjectRelationships(
+                    callContext, repositoryId, objectId, includeSubRelationshipTypes,
+                    direction, typeId, filter, includeAllowableActions,
+                    BigInteger.valueOf(maxItems), BigInteger.valueOf(skipCount), null);
+            
+            ObjectListResponse response = mapToObjectListResponse(relationships, repositoryId, objectId, maxItems, skipCount);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting relationships for object " + objectId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get relationships: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (repositoryService.getRepositoryInfo(repositoryId) == null) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private Properties convertToProperties(RelationshipRequest request) {
+        PropertiesImpl properties = new PropertiesImpl();
+        
+        String typeId = request.getTypeId() != null ? request.getTypeId() : "cmis:relationship";
+        properties.addProperty(new PropertyIdImpl(PropertyIds.OBJECT_TYPE_ID, typeId));
+        properties.addProperty(new PropertyIdImpl(PropertyIds.SOURCE_ID, request.getSourceId()));
+        properties.addProperty(new PropertyIdImpl(PropertyIds.TARGET_ID, request.getTargetId()));
+        
+        if (request.getName() != null) {
+            properties.addProperty(new PropertyStringImpl(PropertyIds.NAME, request.getName()));
+        }
+        
+        addCustomProperties(properties, request.getProperties());
+        
+        return properties;
+    }
+
+    private void addCustomProperties(PropertiesImpl properties, Map<String, PropertyValue> propertyMap) {
+        if (propertyMap == null) {
+            return;
+        }
+
+        for (Map.Entry<String, PropertyValue> entry : propertyMap.entrySet()) {
+            String propertyId = entry.getKey();
+            PropertyValue pv = entry.getValue();
+
+            if (pv == null || pv.getValue() == null) {
+                continue;
+            }
+
+            String type = pv.getType() != null ? pv.getType() : "string";
+            Object value = pv.getValue();
+            boolean isMultiValued = "multi".equals(pv.getCardinality()) || value instanceof List;
+
+            switch (type) {
+                case "id":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyIdImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyIdImpl(propertyId, value.toString()));
+                    }
+                    break;
+                case "boolean":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBooleanList(value)));
+                    } else {
+                        properties.addProperty(new PropertyBooleanImpl(propertyId, convertToBoolean(value)));
+                    }
+                    break;
+                case "integer":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigIntegerList(value)));
+                    } else {
+                        properties.addProperty(new PropertyIntegerImpl(propertyId, convertToBigInteger(value)));
+                    }
+                    break;
+                case "decimal":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimalList(value)));
+                    } else {
+                        properties.addProperty(new PropertyDecimalImpl(propertyId, convertToBigDecimal(value)));
+                    }
+                    break;
+                case "datetime":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendarList(value)));
+                    } else {
+                        properties.addProperty(new PropertyDateTimeImpl(propertyId, convertToCalendar(value)));
+                    }
+                    break;
+                case "html":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyHtmlImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyHtmlImpl(propertyId, value.toString()));
+                    }
+                    break;
+                case "uri":
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyUriImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyUriImpl(propertyId, value.toString()));
+                    }
+                    break;
+                case "string":
+                default:
+                    if (isMultiValued) {
+                        properties.addProperty(new PropertyStringImpl(propertyId, convertToStringList(value)));
+                    } else {
+                        properties.addProperty(new PropertyStringImpl(propertyId, value.toString()));
+                    }
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> convertToStringList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<String> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(item != null ? item.toString() : null);
+            }
+            return result;
+        }
+        return List.of(value.toString());
+    }
+
+    private Boolean convertToBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Boolean> convertToBooleanList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<Boolean> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBoolean(item));
+            }
+            return result;
+        }
+        return List.of(convertToBoolean(value));
+    }
+
+    private BigInteger convertToBigInteger(Object value) {
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof Number) {
+            return BigInteger.valueOf(((Number) value).longValue());
+        }
+        return new BigInteger(value.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<BigInteger> convertToBigIntegerList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigInteger> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigInteger(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigInteger(value));
+    }
+
+    private BigDecimal convertToBigDecimal(Object value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<BigDecimal> convertToBigDecimalList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<BigDecimal> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToBigDecimal(item));
+            }
+            return result;
+        }
+        return List.of(convertToBigDecimal(value));
+    }
+
+    private GregorianCalendar convertToCalendar(Object value) {
+        if (value instanceof GregorianCalendar) {
+            return (GregorianCalendar) value;
+        }
+        String dateStr = value.toString();
+        try {
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+            synchronized (ISO_DATE_FORMAT) {
+                calendar.setTime(ISO_DATE_FORMAT.parse(dateStr));
+            }
+            return calendar;
+        } catch (ParseException e) {
+            logger.warning("Failed to parse datetime: " + dateStr);
+            throw ApiException.invalidArgument("Invalid datetime format: " + dateStr + ". Expected ISO 8601 format (e.g., 2024-01-15T10:30:00Z)");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<GregorianCalendar> convertToCalendarList(Object value) {
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<GregorianCalendar> result = new ArrayList<>();
+            for (Object item : list) {
+                result.add(convertToCalendar(item));
+            }
+            return result;
+        }
+        return List.of(convertToCalendar(value));
+    }
+    
+    private RelationshipDirection parseRelationshipDirection(String direction) {
+        if (direction == null || direction.isEmpty() || "either".equalsIgnoreCase(direction)) {
+            return RelationshipDirection.EITHER;
+        }
+        try {
+            return RelationshipDirection.valueOf(direction.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw ApiException.invalidArgument("Invalid relationship direction: " + direction + 
+                    ". Valid values are: source, target, either");
+        }
+    }
+    
+    private RelationshipResponse mapToRelationshipResponse(ObjectData objectData, String repositoryId) {
+        RelationshipResponse response = new RelationshipResponse();
+        
+        Properties properties = objectData.getProperties();
+        if (properties != null) {
+            response.setObjectId(getStringProperty(properties, PropertyIds.OBJECT_ID));
+            response.setObjectTypeId(getStringProperty(properties, PropertyIds.OBJECT_TYPE_ID));
+            response.setName(getStringProperty(properties, PropertyIds.NAME));
+            response.setSourceId(getStringProperty(properties, PropertyIds.SOURCE_ID));
+            response.setTargetId(getStringProperty(properties, PropertyIds.TARGET_ID));
+            response.setCreatedBy(getStringProperty(properties, PropertyIds.CREATED_BY));
+            response.setCreationDate(getDateProperty(properties, PropertyIds.CREATION_DATE));
+            response.setLastModifiedBy(getStringProperty(properties, PropertyIds.LAST_MODIFIED_BY));
+            response.setLastModificationDate(getDateProperty(properties, PropertyIds.LAST_MODIFICATION_DATE));
+            
+            Map<String, PropertyValue> propertyMap = new HashMap<>();
+            for (PropertyData<?> prop : properties.getPropertyList()) {
+                propertyMap.put(prop.getId(), mapPropertyValue(prop));
+            }
+            response.setProperties(propertyMap);
+        }
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        String objectId = response.getObjectId();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + objectId));
+        if (response.getSourceId() != null) {
+            links.put("source", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + response.getSourceId()));
+        }
+        if (response.getTargetId() != null) {
+            links.put("target", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/objects/" + response.getTargetId()));
+        }
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private ObjectListResponse mapToObjectListResponse(ObjectList objectList, String repositoryId, 
+            String objectId, int maxItems, int skipCount) {
+        ObjectListResponse response = new ObjectListResponse();
+        
+        List<ObjectResponse> items = new ArrayList<>();
+        if (objectList.getObjects() != null) {
+            for (ObjectData obj : objectList.getObjects()) {
+                items.add(mapToObjectResponse(obj, repositoryId));
+            }
+        }
+        response.setObjects(items);
+        response.setHasMoreItems(objectList.hasMoreItems());
+        response.setNumItems(objectList.getNumItems() != null ? objectList.getNumItems().longValue() : null);
+        response.setMaxItems((long) maxItems);
+        response.setSkipCount((long) skipCount);
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/relationships/object/" + objectId + 
+                "?maxItems=" + maxItems + "&skipCount=" + skipCount));
+        if (objectList.hasMoreItems()) {
+            links.put("next", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/relationships/object/" + objectId + 
+                    "?maxItems=" + maxItems + "&skipCount=" + (skipCount + maxItems)));
+        }
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private ObjectResponse mapToObjectResponse(ObjectData objectData, String repositoryId) {
+        ObjectResponse response = new ObjectResponse();
+        
+        Properties properties = objectData.getProperties();
+        if (properties != null) {
+            response.setObjectId(getStringProperty(properties, PropertyIds.OBJECT_ID));
+            response.setObjectTypeId(getStringProperty(properties, PropertyIds.OBJECT_TYPE_ID));
+            response.setBaseTypeId(getStringProperty(properties, PropertyIds.BASE_TYPE_ID));
+            response.setName(getStringProperty(properties, PropertyIds.NAME));
+            response.setCreatedBy(getStringProperty(properties, PropertyIds.CREATED_BY));
+            response.setCreationDate(getDateProperty(properties, PropertyIds.CREATION_DATE));
+            response.setLastModifiedBy(getStringProperty(properties, PropertyIds.LAST_MODIFIED_BY));
+            response.setLastModificationDate(getDateProperty(properties, PropertyIds.LAST_MODIFICATION_DATE));
+            
+            Map<String, PropertyValue> propertyMap = new HashMap<>();
+            for (PropertyData<?> prop : properties.getPropertyList()) {
+                propertyMap.put(prop.getId(), mapPropertyValue(prop));
+            }
+            response.setProperties(propertyMap);
+        }
+        
+        return response;
+    }
+    
+    private String getStringProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() != null) {
+            return prop.getFirstValue().toString();
+        }
+        return null;
+    }
+    
+    private String getDateProperty(Properties properties, String propertyId) {
+        PropertyData<?> prop = properties.getProperties().get(propertyId);
+        if (prop != null && prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                return ISO_DATE_FORMAT.format(cal.getTime());
+            }
+        }
+        return null;
+    }
+    
+    private PropertyValue mapPropertyValue(PropertyData<?> prop) {
+        Object value = prop.getValues() != null && prop.getValues().size() > 1 
+                ? prop.getValues() 
+                : prop.getFirstValue();
+        
+        String type = "string";
+        if (prop.getFirstValue() instanceof Boolean) {
+            type = "boolean";
+        } else if (prop.getFirstValue() instanceof Long || prop.getFirstValue() instanceof Integer || prop.getFirstValue() instanceof BigInteger) {
+            type = "integer";
+        } else if (prop.getFirstValue() instanceof Double || prop.getFirstValue() instanceof Float || prop.getFirstValue() instanceof java.math.BigDecimal) {
+            type = "decimal";
+        } else if (prop.getFirstValue() instanceof GregorianCalendar) {
+            GregorianCalendar cal = (GregorianCalendar) prop.getFirstValue();
+            synchronized (ISO_DATE_FORMAT) {
+                value = ISO_DATE_FORMAT.format(cal.getTime());
+            }
+            type = "datetime";
+        }
+        
+        PropertyValue pv = new PropertyValue(value, type);
+        pv.setPropertyDefinitionId(prop.getId());
+        pv.setLocalName(prop.getLocalName());
+        pv.setDisplayName(prop.getDisplayName());
+        pv.setQueryName(prop.getQueryName());
+        
+        return pv;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/RepositoryResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/RepositoryResource.java
@@ -1,0 +1,382 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.api.v1.model.response.RepositoryInfoResponse;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.data.PermissionMapping;
+import org.apache.chemistry.opencmis.commons.data.RepositoryInfo;
+import org.apache.chemistry.opencmis.commons.definitions.PermissionDefinition;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories")
+@Tag(name = "repositories", description = "Repository management operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class RepositoryResource {
+    
+    private static final Logger logger = Logger.getLogger(RepositoryResource.class.getName());
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @GET
+    @Operation(
+            summary = "List all repositories",
+            description = "Returns a list of all available repositories with their basic information"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of repositories",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = RepositoryInfoResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response listRepositories() {
+        logger.info("API v1: Listing all repositories");
+        
+        try {
+            List<RepositoryInfo> repositoryInfos = repositoryService.getRepositoryInfos();
+            
+            List<RepositoryInfoResponse> responses = new ArrayList<>();
+            for (RepositoryInfo repoInfo : repositoryInfos) {
+                responses.add(mapToResponse(repoInfo, false));
+            }
+            
+            return Response.ok(responses).build();
+        } catch (Exception e) {
+            logger.severe("Error listing repositories: " + e.getMessage());
+            throw ApiException.internalError("Failed to list repositories: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{repositoryId}")
+    @Operation(
+            summary = "Get repository information",
+            description = "Returns detailed information about a specific repository including capabilities"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Repository information",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RepositoryInfoResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Repository not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getRepository(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId) {
+        
+        logger.info("API v1: Getting repository info for: " + repositoryId);
+        
+        try {
+            if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.cmis.factory.info.RepositoryInfo repoInfo = 
+                    repositoryService.getRepositoryInfo(repositoryId);
+            
+            if (repoInfo == null) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            RepositoryInfoResponse response = mapToResponse(repoInfo, true);
+            return Response.ok(response).build();
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting repository " + repositoryId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get repository: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{repositoryId}/capabilities")
+    @Operation(
+            summary = "Get repository capabilities",
+            description = "Returns the capabilities of a specific repository"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Repository capabilities",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Repository not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getRepositoryCapabilities(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId) {
+        
+        logger.info("API v1: Getting capabilities for repository: " + repositoryId);
+        
+        try {
+            if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.cmis.factory.info.RepositoryInfo repoInfo = 
+                    repositoryService.getRepositoryInfo(repositoryId);
+            
+            if (repoInfo == null) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities capabilities = 
+                    mapCapabilities(repoInfo.getCapabilities());
+            
+            return Response.ok(capabilities).build();
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting capabilities for " + repositoryId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get repository capabilities: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{repositoryId}/rootFolder")
+    @Operation(
+            summary = "Get root folder information",
+            description = "Returns information about the root folder of the repository"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Root folder ID and link",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Repository not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getRootFolder(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId) {
+        
+        logger.info("API v1: Getting root folder for repository: " + repositoryId);
+        
+        try {
+            if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            jp.aegif.nemaki.cmis.factory.info.RepositoryInfo repoInfo = 
+                    repositoryService.getRepositoryInfo(repositoryId);
+            
+            if (repoInfo == null) {
+                throw ApiException.repositoryNotFound(repositoryId);
+            }
+            
+            String rootFolderId = repoInfo.getRootFolderId();
+            String baseUri = uriInfo.getBaseUri().toString();
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("rootFolderId", rootFolderId);
+            response.put("_links", Map.of(
+                    "self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/rootFolder"),
+                    "folder", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + rootFolderId),
+                    "children", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/folders/" + rootFolderId + "/children")
+            ));
+            
+            return Response.ok(response).build();
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting root folder for " + repositoryId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get root folder: " + e.getMessage(), e);
+        }
+    }
+    
+    private RepositoryInfoResponse mapToResponse(RepositoryInfo repoInfo, boolean includeDetails) {
+        RepositoryInfoResponse response = new RepositoryInfoResponse();
+        
+        response.setRepositoryId(repoInfo.getId());
+        response.setRepositoryName(repoInfo.getName());
+        response.setRepositoryDescription(repoInfo.getDescription());
+        response.setVendorName(repoInfo.getVendorName());
+        response.setProductName(repoInfo.getProductName());
+        response.setProductVersion(repoInfo.getProductVersion());
+        response.setRootFolderId(repoInfo.getRootFolderId());
+        response.setCmisVersionSupported(repoInfo.getCmisVersionSupported());
+        response.setPrincipalIdAnonymous(repoInfo.getPrincipalIdAnonymous());
+        response.setPrincipalIdAnyone(repoInfo.getPrincipalIdAnyone());
+        response.setThinClientUri(repoInfo.getThinClientUri());
+        response.setLatestChangeLogToken(repoInfo.getLatestChangeLogToken());
+        
+        if (includeDetails) {
+            if (repoInfo.getCapabilities() != null) {
+                response.setCapabilities(mapCapabilities(repoInfo.getCapabilities()));
+            }
+            if (repoInfo.getAclCapabilities() != null) {
+                response.setAclCapabilities(mapAclCapabilities(repoInfo.getAclCapabilities()));
+            }
+        }
+        
+        // Add HATEOAS links
+        String baseUri = uriInfo.getBaseUri().toString();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId()));
+        links.put("rootFolder", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/rootFolder"));
+        links.put("types", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/types"));
+        links.put("objects", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/objects"));
+        links.put("query", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/query"));
+        links.put("users", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/users"));
+        links.put("groups", LinkInfo.of(baseUri + "repositories/" + repoInfo.getId() + "/groups"));
+        response.setLinks(links);
+        
+        return response;
+    }
+    
+    private jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities mapCapabilities(
+            org.apache.chemistry.opencmis.commons.data.RepositoryCapabilities caps) {
+        if (caps == null) return null;
+        
+        jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities response = 
+                new jp.aegif.nemaki.api.v1.model.response.RepositoryCapabilities();
+        
+        if (caps.getAclCapability() != null) {
+            response.setCapabilityAcl(caps.getAclCapability().value());
+        }
+        response.setCapabilityAllVersionsSearchable(caps.isAllVersionsSearchableSupported());
+        if (caps.getChangesCapability() != null) {
+            response.setCapabilityChanges(caps.getChangesCapability().value());
+        }
+        if (caps.getContentStreamUpdatesCapability() != null) {
+            response.setCapabilityContentStreamUpdatability(caps.getContentStreamUpdatesCapability().value());
+        }
+        response.setCapabilityGetDescendants(caps.isGetDescendantsSupported());
+        response.setCapabilityGetFolderTree(caps.isGetFolderTreeSupported());
+        if (caps.getOrderByCapability() != null) {
+            response.setCapabilityOrderBy(caps.getOrderByCapability().value());
+        }
+        response.setCapabilityMultifiling(caps.isMultifilingSupported());
+        response.setCapabilityPwcSearchable(caps.isPwcSearchableSupported());
+        response.setCapabilityPwcUpdatable(caps.isPwcUpdatableSupported());
+        if (caps.getQueryCapability() != null) {
+            response.setCapabilityQuery(caps.getQueryCapability().value());
+        }
+        if (caps.getRenditionsCapability() != null) {
+            response.setCapabilityRenditions(caps.getRenditionsCapability().value());
+        }
+        response.setCapabilityUnfiling(caps.isUnfilingSupported());
+        response.setCapabilityVersionSpecificFiling(caps.isVersionSpecificFilingSupported());
+        if (caps.getJoinCapability() != null) {
+            response.setCapabilityJoin(caps.getJoinCapability().value());
+        }
+        
+        return response;
+    }
+    
+    private jp.aegif.nemaki.api.v1.model.response.AclCapabilities mapAclCapabilities(
+            org.apache.chemistry.opencmis.commons.data.AclCapabilities aclCaps) {
+        if (aclCaps == null) return null;
+        
+        jp.aegif.nemaki.api.v1.model.response.AclCapabilities response = 
+                new jp.aegif.nemaki.api.v1.model.response.AclCapabilities();
+        
+        if (aclCaps.getSupportedPermissions() != null) {
+            response.setSupportedPermissions(aclCaps.getSupportedPermissions().value());
+        }
+        if (aclCaps.getAclPropagation() != null) {
+            response.setAclPropagation(aclCaps.getAclPropagation().value());
+        }
+        
+        // Map permissions
+        if (aclCaps.getPermissions() != null) {
+            List<jp.aegif.nemaki.api.v1.model.response.AclCapabilities.PermissionDefinition> permissions = new ArrayList<>();
+            for (PermissionDefinition perm : aclCaps.getPermissions()) {
+                permissions.add(new jp.aegif.nemaki.api.v1.model.response.AclCapabilities.PermissionDefinition(
+                        perm.getId(), perm.getDescription()));
+            }
+            response.setPermissions(permissions);
+        }
+        
+        // Map permission mapping
+        if (aclCaps.getPermissionMapping() != null) {
+            Map<String, List<String>> mapping = new HashMap<>();
+            for (PermissionMapping pm : aclCaps.getPermissionMapping().values()) {
+                mapping.put(pm.getKey(), pm.getPermissions());
+            }
+            response.setPermissionMapping(mapping);
+        }
+        
+        return response;
+    }
+}

--- a/core/src/main/java/jp/aegif/nemaki/api/v1/resource/TypeResource.java
+++ b/core/src/main/java/jp/aegif/nemaki/api/v1/resource/TypeResource.java
@@ -1,0 +1,572 @@
+package jp.aegif.nemaki.api.v1.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import jp.aegif.nemaki.api.v1.exception.ApiException;
+import jp.aegif.nemaki.api.v1.exception.ProblemDetail;
+import jp.aegif.nemaki.api.v1.model.response.LinkInfo;
+import jp.aegif.nemaki.cmis.service.RepositoryService;
+
+import org.apache.chemistry.opencmis.commons.definitions.PropertyDefinition;
+import org.apache.chemistry.opencmis.commons.definitions.TypeDefinition;
+import org.apache.chemistry.opencmis.commons.definitions.TypeDefinitionContainer;
+import org.apache.chemistry.opencmis.commons.definitions.TypeDefinitionList;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+@Component
+@Path("/repositories/{repositoryId}/types")
+@Tag(name = "types", description = "CMIS type definition operations")
+@Produces(MediaType.APPLICATION_JSON)
+public class TypeResource {
+    
+    private static final Logger logger = Logger.getLogger(TypeResource.class.getName());
+    
+    @Autowired
+    private RepositoryService repositoryService;
+    
+    @Context
+    private UriInfo uriInfo;
+    
+    @Context
+    private HttpServletRequest httpRequest;
+    
+    @GET
+    @Operation(
+            summary = "Get type children",
+            description = "Gets the list of child types for the specified type (or root types if no typeId specified)"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of type definitions",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Type not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getTypeChildren(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Parent type ID (null for root types)")
+            @QueryParam("typeId") String typeId,
+            @Parameter(description = "Include property definitions")
+            @QueryParam("includePropertyDefinitions") @DefaultValue("false") Boolean includePropertyDefinitions,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems,
+            @Parameter(description = "Number of items to skip")
+            @QueryParam("skipCount") @DefaultValue("0") Integer skipCount) {
+        
+        logger.info("API v1: Getting type children for repository " + repositoryId + ", typeId=" + typeId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            TypeDefinitionList typeList = repositoryService.getTypeChildren(
+                    callContext, repositoryId, typeId, includePropertyDefinitions,
+                    BigInteger.valueOf(maxItems), BigInteger.valueOf(skipCount), null);
+            
+            List<Map<String, Object>> types = new ArrayList<>();
+            if (typeList != null && typeList.getList() != null) {
+                for (TypeDefinition typeDef : typeList.getList()) {
+                    types.add(mapTypeDefinition(typeDef, repositoryId, includePropertyDefinitions));
+                }
+            }
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("types", types);
+            response.put("numItems", typeList != null && typeList.getNumItems() != null 
+                    ? typeList.getNumItems().longValue() : (long) types.size());
+            response.put("hasMoreItems", typeList != null && typeList.hasMoreItems() != null 
+                    ? typeList.hasMoreItems() : false);
+            response.put("skipCount", skipCount);
+            response.put("maxItems", maxItems);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            String selfUrl = baseUri + "repositories/" + repositoryId + "/types?maxItems=" + maxItems + "&skipCount=" + skipCount;
+            if (typeId != null) {
+                selfUrl += "&typeId=" + typeId;
+            }
+            links.put("self", LinkInfo.of(selfUrl));
+            
+            if (typeList != null && typeList.hasMoreItems() != null && typeList.hasMoreItems()) {
+                int nextSkip = skipCount + maxItems;
+                String nextUrl = baseUri + "repositories/" + repositoryId + "/types?maxItems=" + maxItems + "&skipCount=" + nextSkip;
+                if (typeId != null) {
+                    nextUrl += "&typeId=" + typeId;
+                }
+                links.put("next", LinkInfo.of(nextUrl));
+            }
+            
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting type children: " + e.getMessage());
+            throw ApiException.internalError("Failed to get type children: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{typeId}")
+    @Operation(
+            summary = "Get type definition",
+            description = "Gets the definition of the specified type"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Type definition",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Type not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getTypeDefinition(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Type ID", required = true, example = "cmis:document")
+            @PathParam("typeId") String typeId) {
+        
+        logger.info("API v1: Getting type definition for " + typeId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            TypeDefinition typeDef = repositoryService.getTypeDefinition(
+                    callContext, repositoryId, typeId, null);
+            
+            if (typeDef == null) {
+                throw ApiException.typeNotFound(typeId, repositoryId);
+            }
+            
+            Map<String, Object> response = mapTypeDefinition(typeDef, repositoryId, true);
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting type definition for " + typeId + ": " + e.getMessage());
+            if (e.getMessage() != null && e.getMessage().contains("not found")) {
+                throw ApiException.typeNotFound(typeId, repositoryId);
+            }
+            throw ApiException.internalError("Failed to get type definition: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{typeId}/children")
+    @Operation(
+            summary = "Get type children",
+            description = "Gets the list of child types for the specified type"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of child type definitions",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Type not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getTypeChildrenByTypeId(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Type ID", required = true, example = "cmis:document")
+            @PathParam("typeId") String typeId,
+            @Parameter(description = "Include property definitions")
+            @QueryParam("includePropertyDefinitions") @DefaultValue("false") Boolean includePropertyDefinitions,
+            @Parameter(description = "Maximum number of items to return")
+            @QueryParam("maxItems") @DefaultValue("100") Integer maxItems,
+            @Parameter(description = "Number of items to skip")
+            @QueryParam("skipCount") @DefaultValue("0") Integer skipCount) {
+        
+        logger.info("API v1: Getting children of type " + typeId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            TypeDefinitionList typeList = repositoryService.getTypeChildren(
+                    callContext, repositoryId, typeId, includePropertyDefinitions,
+                    BigInteger.valueOf(maxItems), BigInteger.valueOf(skipCount), null);
+            
+            List<Map<String, Object>> types = new ArrayList<>();
+            if (typeList != null && typeList.getList() != null) {
+                for (TypeDefinition typeDef : typeList.getList()) {
+                    types.add(mapTypeDefinition(typeDef, repositoryId, includePropertyDefinitions));
+                }
+            }
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("parentTypeId", typeId);
+            response.put("types", types);
+            response.put("numItems", typeList != null && typeList.getNumItems() != null 
+                    ? typeList.getNumItems().longValue() : (long) types.size());
+            response.put("hasMoreItems", typeList != null && typeList.hasMoreItems() != null 
+                    ? typeList.hasMoreItems() : false);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeId + "/children?maxItems=" + maxItems + "&skipCount=" + skipCount));
+            links.put("type", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeId));
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting children of type " + typeId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get type children: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{typeId}/descendants")
+    @Operation(
+            summary = "Get type descendants",
+            description = "Gets the set of descendant types for the specified type"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Tree of descendant type definitions",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Type not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getTypeDescendants(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Type ID", required = true, example = "cmis:document")
+            @PathParam("typeId") String typeId,
+            @Parameter(description = "Depth of descendants to return (-1 for all)")
+            @QueryParam("depth") @DefaultValue("-1") Integer depth,
+            @Parameter(description = "Include property definitions")
+            @QueryParam("includePropertyDefinitions") @DefaultValue("false") Boolean includePropertyDefinitions) {
+        
+        logger.info("API v1: Getting descendants of type " + typeId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            List<TypeDefinitionContainer> descendants = repositoryService.getTypeDescendants(
+                    callContext, repositoryId, typeId, BigInteger.valueOf(depth),
+                    includePropertyDefinitions, null);
+            
+            List<Map<String, Object>> descendantTree = mapTypeDescendants(descendants, repositoryId, includePropertyDefinitions);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("typeId", typeId);
+            response.put("depth", depth);
+            response.put("descendants", descendantTree);
+            
+            String baseUri = uriInfo.getBaseUri().toString();
+            Map<String, LinkInfo> links = new HashMap<>();
+            links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeId + "/descendants?depth=" + depth));
+            links.put("type", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeId));
+            response.put("_links", links);
+            
+            return Response.ok(response).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting descendants of type " + typeId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get type descendants: " + e.getMessage(), e);
+        }
+    }
+    
+    @GET
+    @Path("/{typeId}/schema")
+    @Operation(
+            summary = "Get OpenAPI schema for type",
+            description = "Generates an OpenAPI-compatible JSON Schema for the specified CMIS type"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "JSON Schema for the type",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Type not found",
+                    content = @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)
+                    )
+            )
+    })
+    public Response getTypeSchema(
+            @Parameter(description = "Repository ID", required = true, example = "bedroom")
+            @PathParam("repositoryId") String repositoryId,
+            @Parameter(description = "Type ID", required = true, example = "cmis:document")
+            @PathParam("typeId") String typeId) {
+        
+        logger.info("API v1: Getting schema for type " + typeId + " from repository " + repositoryId);
+        
+        try {
+            validateRepository(repositoryId);
+            CallContext callContext = getCallContext();
+            
+            TypeDefinition typeDef = repositoryService.getTypeDefinition(
+                    callContext, repositoryId, typeId, null);
+            
+            if (typeDef == null) {
+                throw ApiException.typeNotFound(typeId, repositoryId);
+            }
+            
+            Map<String, Object> schema = generateJsonSchema(typeDef, repositoryId);
+            return Response.ok(schema).build();
+            
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.severe("Error getting schema for type " + typeId + ": " + e.getMessage());
+            throw ApiException.internalError("Failed to get type schema: " + e.getMessage(), e);
+        }
+    }
+    
+    private void validateRepository(String repositoryId) {
+        if (!repositoryService.hasThisRepositoryId(repositoryId)) {
+            throw ApiException.repositoryNotFound(repositoryId);
+        }
+    }
+    
+    private CallContext getCallContext() {
+        CallContext callContext = (CallContext) httpRequest.getAttribute("CallContext");
+        if (callContext == null) {
+            throw ApiException.unauthorized("Authentication required");
+        }
+        return callContext;
+    }
+    
+    private Map<String, Object> mapTypeDefinition(TypeDefinition typeDef, String repositoryId, Boolean includePropertyDefinitions) {
+        Map<String, Object> result = new HashMap<>();
+        
+        result.put("id", typeDef.getId());
+        result.put("localName", typeDef.getLocalName());
+        result.put("localNamespace", typeDef.getLocalNamespace());
+        result.put("displayName", typeDef.getDisplayName());
+        result.put("queryName", typeDef.getQueryName());
+        result.put("description", typeDef.getDescription());
+        result.put("baseId", typeDef.getBaseTypeId() != null ? typeDef.getBaseTypeId().value() : null);
+        result.put("parentId", typeDef.getParentTypeId());
+        result.put("isCreatable", typeDef.isCreatable());
+        result.put("isFileable", typeDef.isFileable());
+        result.put("isQueryable", typeDef.isQueryable());
+        result.put("isFulltextIndexed", typeDef.isFulltextIndexed());
+        result.put("isIncludedInSupertypeQuery", typeDef.isIncludedInSupertypeQuery());
+        result.put("isControllablePolicy", typeDef.isControllablePolicy());
+        result.put("isControllableAcl", typeDef.isControllableAcl());
+        
+        if (includePropertyDefinitions != null && includePropertyDefinitions && typeDef.getPropertyDefinitions() != null) {
+            Map<String, Object> propertyDefinitions = new HashMap<>();
+            for (Map.Entry<String, PropertyDefinition<?>> entry : typeDef.getPropertyDefinitions().entrySet()) {
+                propertyDefinitions.put(entry.getKey(), mapPropertyDefinition(entry.getValue()));
+            }
+            result.put("propertyDefinitions", propertyDefinitions);
+        }
+        
+        String baseUri = uriInfo.getBaseUri().toString();
+        Map<String, LinkInfo> links = new HashMap<>();
+        links.put("self", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeDef.getId()));
+        links.put("children", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeDef.getId() + "/children"));
+        links.put("descendants", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeDef.getId() + "/descendants"));
+        links.put("schema", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeDef.getId() + "/schema"));
+        if (typeDef.getParentTypeId() != null) {
+            links.put("parent", LinkInfo.of(baseUri + "repositories/" + repositoryId + "/types/" + typeDef.getParentTypeId()));
+        }
+        result.put("_links", links);
+        
+        return result;
+    }
+    
+    private Map<String, Object> mapPropertyDefinition(PropertyDefinition<?> propDef) {
+        Map<String, Object> result = new HashMap<>();
+        
+        result.put("id", propDef.getId());
+        result.put("localName", propDef.getLocalName());
+        result.put("localNamespace", propDef.getLocalNamespace());
+        result.put("displayName", propDef.getDisplayName());
+        result.put("queryName", propDef.getQueryName());
+        result.put("description", propDef.getDescription());
+        result.put("propertyType", propDef.getPropertyType() != null ? propDef.getPropertyType().value() : null);
+        result.put("cardinality", propDef.getCardinality() != null ? propDef.getCardinality().value() : null);
+        result.put("updatability", propDef.getUpdatability() != null ? propDef.getUpdatability().value() : null);
+        result.put("isInherited", propDef.isInherited());
+        result.put("isRequired", propDef.isRequired());
+        result.put("isQueryable", propDef.isQueryable());
+        result.put("isOrderable", propDef.isOrderable());
+        result.put("isOpenChoice", propDef.isOpenChoice());
+        
+        return result;
+    }
+    
+    private List<Map<String, Object>> mapTypeDescendants(List<TypeDefinitionContainer> containers, 
+            String repositoryId, Boolean includePropertyDefinitions) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        
+        if (containers != null) {
+            for (TypeDefinitionContainer container : containers) {
+                Map<String, Object> item = new HashMap<>();
+                
+                if (container.getTypeDefinition() != null) {
+                    item.put("type", mapTypeDefinition(container.getTypeDefinition(), repositoryId, includePropertyDefinitions));
+                }
+                
+                if (container.getChildren() != null && !container.getChildren().isEmpty()) {
+                    item.put("children", mapTypeDescendants(container.getChildren(), repositoryId, includePropertyDefinitions));
+                }
+                
+                result.add(item);
+            }
+        }
+        
+        return result;
+    }
+    
+    private Map<String, Object> generateJsonSchema(TypeDefinition typeDef, String repositoryId) {
+        Map<String, Object> schema = new HashMap<>();
+        
+        schema.put("$schema", "http://json-schema.org/draft-07/schema#");
+        schema.put("$id", uriInfo.getBaseUri().toString() + "repositories/" + repositoryId + "/types/" + typeDef.getId() + "/schema");
+        schema.put("title", typeDef.getDisplayName() != null ? typeDef.getDisplayName() : typeDef.getId());
+        schema.put("description", typeDef.getDescription());
+        schema.put("type", "object");
+        
+        Map<String, Object> properties = new HashMap<>();
+        List<String> required = new ArrayList<>();
+        
+        properties.put("objectId", Map.of("type", "string", "description", "Object ID"));
+        properties.put("objectTypeId", Map.of("type", "string", "description", "Object type ID", "const", typeDef.getId()));
+        properties.put("baseTypeId", Map.of("type", "string", "description", "Base type ID"));
+        
+        if (typeDef.getPropertyDefinitions() != null) {
+            Map<String, Object> propertiesSchema = new HashMap<>();
+            
+            for (Map.Entry<String, PropertyDefinition<?>> entry : typeDef.getPropertyDefinitions().entrySet()) {
+                PropertyDefinition<?> propDef = entry.getValue();
+                Map<String, Object> propSchema = new HashMap<>();
+                
+                propSchema.put("type", "object");
+                propSchema.put("description", propDef.getDescription() != null ? propDef.getDescription() : propDef.getDisplayName());
+                
+                Map<String, Object> propProperties = new HashMap<>();
+                
+                String jsonType = "string";
+                if (propDef.getPropertyType() != null) {
+                    switch (propDef.getPropertyType()) {
+                        case BOOLEAN:
+                            jsonType = "boolean";
+                            break;
+                        case INTEGER:
+                            jsonType = "integer";
+                            break;
+                        case DECIMAL:
+                            jsonType = "number";
+                            break;
+                        case DATETIME:
+                            jsonType = "string";
+                            propProperties.put("format", "date-time");
+                            break;
+                        default:
+                            jsonType = "string";
+                    }
+                }
+                
+                if (propDef.getCardinality() != null && "multi".equals(propDef.getCardinality().value())) {
+                    propProperties.put("value", Map.of("type", "array", "items", Map.of("type", jsonType)));
+                } else {
+                    propProperties.put("value", Map.of("type", jsonType));
+                }
+                
+                propProperties.put("type", Map.of(
+                        "type", "string",
+                        "enum", List.of("string", "boolean", "integer", "decimal", "datetime", "uri", "id", "html")
+                ));
+                
+                propSchema.put("properties", propProperties);
+                propSchema.put("required", List.of("value", "type"));
+                
+                propertiesSchema.put(propDef.getId(), propSchema);
+                
+                if (propDef.isRequired() != null && propDef.isRequired()) {
+                    required.add(propDef.getId());
+                }
+            }
+            
+            properties.put("properties", Map.of(
+                    "type", "object",
+                    "description", "Object properties with 2-layer structure (value/type)",
+                    "properties", propertiesSchema,
+                    "required", required
+            ));
+        }
+        
+        schema.put("properties", properties);
+        schema.put("required", List.of("objectTypeId"));
+        
+        return schema;
+    }
+}

--- a/core/src/main/webapp/WEB-INF/web.xml
+++ b/core/src/main/webapp/WEB-INF/web.xml
@@ -132,6 +132,10 @@
 		<filter-name>corsFilter</filter-name>
 		<url-pattern>/rest/*</url-pattern>
 	</filter-mapping>
+	<filter-mapping>
+		<filter-name>corsFilter</filter-name>
+		<url-pattern>/api/v1/*</url-pattern>
+	</filter-mapping>
 	
 	<!-- DeleteType filter mapping - TEMPORARILY DISABLED to allow query action support -->
 	<!-- CRITICAL FIX: This filter mapping prevents cmisaction=query from working in TCK tests -->
@@ -195,6 +199,11 @@
 	<filter-mapping>
 		<filter-name>restAuthenticationFilter</filter-name>
 		<url-pattern>/api/*</url-pattern>
+	</filter-mapping>
+	<!-- Apply authentication to /api/v1/* endpoints (OpenAPI REST API v1) -->
+	<filter-mapping>
+		<filter-name>restAuthenticationFilter</filter-name>
+		<url-pattern>/api/v1/*</url-pattern>
 	</filter-mapping>
 
 
@@ -270,6 +279,27 @@
  <servlet-mapping>
   <servlet-name>jersey-app</servlet-name>
   <url-pattern>/rest/*</url-pattern>
+ </servlet-mapping>
+
+ <!-- Jersey application for OpenAPI v1 REST endpoints -->
+ <servlet>
+  <servlet-name>jersey-api-v1</servlet-name>
+  <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+  <init-param>
+        <param-name>jakarta.ws.rs.Application</param-name>
+        <param-value>jp.aegif.nemaki.api.v1.ApiV1Application</param-value>
+    </init-param>
+    <!-- Enable Jersey-Spring integration -->
+    <init-param>
+        <param-name>jersey.config.server.provider.classnames</param-name>
+        <param-value>org.glassfish.jersey.server.spring.SpringLifecycleListener</param-value>
+    </init-param>
+    <load-on-startup>11</load-on-startup>
+ </servlet>
+
+ <servlet-mapping>
+  <servlet-name>jersey-api-v1</servlet-name>
+  <url-pattern>/api/v1/*</url-pattern>
  </servlet-mapping>
 
  <!-- Simple servlet for /rest/all/repositories endpoint -->

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/AclResourceIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/AclResourceIT.java
@@ -1,0 +1,352 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * E2E/Integration tests for AclResource endpoints.
+ * 
+ * Tests the following endpoints:
+ * - GET /repositories/{repoId}/objects/{objectId}/acl - Get ACL
+ * - PUT /repositories/{repoId}/objects/{objectId}/acl - Apply ACL
+ * 
+ * Run with: mvn test -Dtest=AclResourceIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class AclResourceIT extends ApiV1TestBase {
+    
+    @Test
+    public void testGetAcl_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(aclPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objectId", equalTo(rootFolderId))
+            .body("aces", notNullValue())
+            .body("links", notNullValue());
+    }
+    
+    @Test
+    public void testGetAcl_ContainsAceEntries() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(aclPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .body("aces", notNullValue());
+    }
+    
+    @Test
+    public void testGetAcl_ContainsExactFlag() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(aclPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .body("exact", notNullValue());
+    }
+    
+    @Test
+    public void testGetAcl_InvalidObjectId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(aclPath("nonexistent-object-12345"))
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testApplyAcl_ValidRequest_ReturnsOk() {
+        // First create a test folder to apply ACL to
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("parentId", rootFolderId);
+        folderRequest.put("name", "acl-test-folder-" + System.currentTimeMillis());
+        folderRequest.put("typeId", "cmis:folder");
+        
+        Response createResponse = given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String folderId = createResponse.path("objectId");
+        
+        try {
+            // Apply ACL
+            Map<String, Object> aceEntry = new HashMap<>();
+            aceEntry.put("principalId", "admin");
+            aceEntry.put("permissions", new String[]{"cmis:all"});
+            
+            List<Map<String, Object>> aces = new ArrayList<>();
+            aces.add(aceEntry);
+            
+            Map<String, Object> aclRequest = new HashMap<>();
+            aclRequest.put("aces", aces);
+            aclRequest.put("aclPropagation", "REPOSITORYDETERMINED");
+            
+            given()
+                .spec(requestSpec)
+                .body(aclRequest)
+            .when()
+                .put(aclPath(folderId))
+            .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("objectId", equalTo(folderId))
+                .body("aces", notNullValue());
+            
+        } finally {
+            // Clean up
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(folderId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testApplyAcl_WithObjectOnlyPropagation_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("parentId", rootFolderId);
+        folderRequest.put("name", "acl-objectonly-test-" + System.currentTimeMillis());
+        folderRequest.put("typeId", "cmis:folder");
+        
+        Response createResponse = given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String folderId = createResponse.path("objectId");
+        
+        try {
+            Map<String, Object> aceEntry = new HashMap<>();
+            aceEntry.put("principalId", "admin");
+            aceEntry.put("permissions", new String[]{"cmis:read"});
+            
+            List<Map<String, Object>> aces = new ArrayList<>();
+            aces.add(aceEntry);
+            
+            Map<String, Object> aclRequest = new HashMap<>();
+            aclRequest.put("aces", aces);
+            aclRequest.put("aclPropagation", "OBJECTONLY");
+            
+            given()
+                .spec(requestSpec)
+                .body(aclRequest)
+            .when()
+                .put(aclPath(folderId))
+            .then()
+                .statusCode(200);
+            
+        } finally {
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(folderId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testApplyAcl_WithPropagatePropagation_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("parentId", rootFolderId);
+        folderRequest.put("name", "acl-propagate-test-" + System.currentTimeMillis());
+        folderRequest.put("typeId", "cmis:folder");
+        
+        Response createResponse = given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String folderId = createResponse.path("objectId");
+        
+        try {
+            Map<String, Object> aceEntry = new HashMap<>();
+            aceEntry.put("principalId", "admin");
+            aceEntry.put("permissions", new String[]{"cmis:write"});
+            
+            List<Map<String, Object>> aces = new ArrayList<>();
+            aces.add(aceEntry);
+            
+            Map<String, Object> aclRequest = new HashMap<>();
+            aclRequest.put("aces", aces);
+            aclRequest.put("aclPropagation", "PROPAGATE");
+            
+            given()
+                .spec(requestSpec)
+                .body(aclRequest)
+            .when()
+                .put(aclPath(folderId))
+            .then()
+                .statusCode(200);
+            
+        } finally {
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(folderId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testApplyAcl_InvalidObjectId_Returns404() {
+        Map<String, Object> aceEntry = new HashMap<>();
+        aceEntry.put("principalId", "admin");
+        aceEntry.put("permissions", new String[]{"cmis:all"});
+        
+        List<Map<String, Object>> aces = new ArrayList<>();
+        aces.add(aceEntry);
+        
+        Map<String, Object> aclRequest = new HashMap<>();
+        aclRequest.put("aces", aces);
+        
+        given()
+            .spec(requestSpec)
+            .body(aclRequest)
+        .when()
+            .put(aclPath("nonexistent-object-12345"))
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testApplyAcl_InvalidPropagation_Returns400() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> aceEntry = new HashMap<>();
+        aceEntry.put("principalId", "admin");
+        aceEntry.put("permissions", new String[]{"cmis:all"});
+        
+        List<Map<String, Object>> aces = new ArrayList<>();
+        aces.add(aceEntry);
+        
+        Map<String, Object> aclRequest = new HashMap<>();
+        aclRequest.put("aces", aces);
+        aclRequest.put("aclPropagation", "INVALID_PROPAGATION");
+        
+        given()
+            .spec(requestSpec)
+            .body(aclRequest)
+        .when()
+            .put(aclPath(rootFolderId))
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testGetAcl_ContainsHATEOASLinks() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(aclPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .body("links.self", notNullValue())
+            .body("links.self.href", containsString("acl"))
+            .body("links.object", notNullValue());
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ApiV1TestBase.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ApiV1TestBase.java
@@ -23,7 +23,7 @@ import org.junit.BeforeClass;
  */
 public abstract class ApiV1TestBase {
     
-    protected static final String API_V1_PATH = "/api/v1";
+    protected static final String API_V1_PATH = "/api/v1/cmis";
     
     protected static String baseUrl;
     protected static String username;

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ApiV1TestBase.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ApiV1TestBase.java
@@ -1,0 +1,155 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.junit.BeforeClass;
+
+/**
+ * Base class for API v1 E2E/integration tests using REST Assured.
+ * 
+ * These tests are designed to run against a deployed NemakiWare instance.
+ * Configure the base URL and credentials via system properties or environment variables:
+ * 
+ * - nemaki.test.baseUrl: Base URL of the NemakiWare instance (default: http://localhost:8080/core)
+ * - nemaki.test.username: Test user username (default: admin)
+ * - nemaki.test.password: Test user password (default: admin)
+ * - nemaki.test.repositoryId: Repository ID to test against (default: bedroom)
+ * 
+ * Example:
+ *   mvn test -Dnemaki.test.baseUrl=http://localhost:8080/core -Dnemaki.test.username=admin
+ */
+public abstract class ApiV1TestBase {
+    
+    protected static final String API_V1_PATH = "/api/v1";
+    
+    protected static String baseUrl;
+    protected static String username;
+    protected static String password;
+    protected static String repositoryId;
+    
+    protected static RequestSpecification requestSpec;
+    
+    @BeforeClass
+    public static void setupRestAssured() {
+        // Load configuration from system properties or environment variables
+        baseUrl = getConfigValue("nemaki.test.baseUrl", "NEMAKI_TEST_BASE_URL", "http://localhost:8080/core");
+        username = getConfigValue("nemaki.test.username", "NEMAKI_TEST_USERNAME", "admin");
+        password = getConfigValue("nemaki.test.password", "NEMAKI_TEST_PASSWORD", "admin");
+        repositoryId = getConfigValue("nemaki.test.repositoryId", "NEMAKI_TEST_REPOSITORY_ID", "bedroom");
+        
+        // Configure REST Assured
+        RestAssured.baseURI = baseUrl;
+        RestAssured.basePath = API_V1_PATH;
+        
+        // Build request specification with common settings
+        requestSpec = new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setAccept(ContentType.JSON)
+                .addHeader("Authorization", createBasicAuthHeader(username, password))
+                .log(LogDetail.METHOD)
+                .log(LogDetail.URI)
+                .build();
+    }
+    
+    /**
+     * Get configuration value from system property, environment variable, or default.
+     */
+    protected static String getConfigValue(String sysProp, String envVar, String defaultValue) {
+        String value = System.getProperty(sysProp);
+        if (value == null || value.isEmpty()) {
+            value = System.getenv(envVar);
+        }
+        if (value == null || value.isEmpty()) {
+            value = defaultValue;
+        }
+        return value;
+    }
+    
+    /**
+     * Create Basic Authentication header value.
+     */
+    protected static String createBasicAuthHeader(String user, String pass) {
+        String credentials = user + ":" + pass;
+        return "Basic " + java.util.Base64.getEncoder().encodeToString(credentials.getBytes());
+    }
+    
+    /**
+     * Get the repositories endpoint path.
+     */
+    protected String repositoriesPath() {
+        return "/repositories";
+    }
+    
+    /**
+     * Get the repository-specific base path.
+     */
+    protected String repositoryPath() {
+        return "/repositories/" + repositoryId;
+    }
+    
+    /**
+     * Get the objects endpoint path for the configured repository.
+     */
+    protected String objectsPath() {
+        return repositoryPath() + "/objects";
+    }
+    
+    /**
+     * Get the path for a specific object.
+     */
+    protected String objectPath(String objectId) {
+        return objectsPath() + "/" + objectId;
+    }
+    
+    /**
+     * Get the folders endpoint path for the configured repository.
+     */
+    protected String foldersPath() {
+        return repositoryPath() + "/folders";
+    }
+    
+    /**
+     * Get the documents endpoint path for the configured repository.
+     */
+    protected String documentsPath() {
+        return repositoryPath() + "/documents";
+    }
+    
+    /**
+     * Get the types endpoint path for the configured repository.
+     */
+    protected String typesPath() {
+        return repositoryPath() + "/types";
+    }
+    
+    /**
+     * Get the query endpoint path for the configured repository.
+     */
+    protected String queryPath() {
+        return repositoryPath() + "/query";
+    }
+    
+    /**
+     * Get the ACL endpoint path for a specific object.
+     */
+    protected String aclPath(String objectId) {
+        return objectsPath() + "/" + objectId + "/acl";
+    }
+    
+    /**
+     * Get the relationships endpoint path for the configured repository.
+     */
+    protected String relationshipsPath() {
+        return repositoryPath() + "/relationships";
+    }
+    
+    /**
+     * Get the policies endpoint path for the configured repository.
+     */
+    protected String policiesPath() {
+        return repositoryPath() + "/policies";
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/DocumentResourceIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/DocumentResourceIT.java
@@ -1,0 +1,318 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * E2E/Integration tests for DocumentResource endpoints.
+ * 
+ * Tests the following endpoints:
+ * - POST /repositories/{repoId}/documents - Create document
+ * - POST /repositories/{repoId}/documents/{docId}/checkout - Check out document
+ * - POST /repositories/{repoId}/documents/{docId}/checkin - Check in document
+ * - POST /repositories/{repoId}/documents/{docId}/cancelCheckout - Cancel checkout
+ * - GET /repositories/{repoId}/documents/{docId}/versions - Get all versions
+ * - GET /repositories/{repoId}/documents/{docId}/latestVersion - Get latest version
+ * - GET /repositories/{repoId}/documents/checkedout - Get checked out documents
+ * 
+ * Run with: mvn test -Dtest=DocumentResourceIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class DocumentResourceIT extends ApiV1TestBase {
+    
+    @Test
+    public void testCreateDocument_ValidRequest_ReturnsCreated() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> docRequest = new HashMap<>();
+        docRequest.put("parentId", rootFolderId);
+        docRequest.put("name", "test-document-" + System.currentTimeMillis() + ".txt");
+        docRequest.put("typeId", "cmis:document");
+        
+        Response response = given()
+            .spec(requestSpec)
+            .body(docRequest)
+        .when()
+            .post(documentsPath())
+        .then()
+            .statusCode(201)
+            .contentType("application/json")
+            .body("objectId", notNullValue())
+            .body("objectTypeId", equalTo("cmis:document"))
+            .body("links", notNullValue())
+            .extract()
+            .response();
+        
+        // Clean up: delete the created document
+        String docId = response.path("objectId");
+        if (docId != null) {
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(docId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testCreateDocument_WithProperties_ReturnsCreated() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> nameProperty = new HashMap<>();
+        nameProperty.put("value", "test-doc-with-props-" + System.currentTimeMillis() + ".txt");
+        nameProperty.put("type", "string");
+        
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("cmis:name", nameProperty);
+        
+        Map<String, Object> docRequest = new HashMap<>();
+        docRequest.put("parentId", rootFolderId);
+        docRequest.put("typeId", "cmis:document");
+        docRequest.put("properties", properties);
+        
+        Response response = given()
+            .spec(requestSpec)
+            .body(docRequest)
+        .when()
+            .post(documentsPath())
+        .then()
+            .statusCode(201)
+            .body("objectId", notNullValue())
+            .extract()
+            .response();
+        
+        // Clean up
+        String docId = response.path("objectId");
+        if (docId != null) {
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(docId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testCreateDocument_MissingParentId_Returns400() {
+        Map<String, Object> docRequest = new HashMap<>();
+        docRequest.put("name", "test-document-no-parent.txt");
+        docRequest.put("typeId", "cmis:document");
+        
+        given()
+            .spec(requestSpec)
+            .body(docRequest)
+        .when()
+            .post(documentsPath())
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testCreateDocument_InvalidParentId_Returns404() {
+        Map<String, Object> docRequest = new HashMap<>();
+        docRequest.put("parentId", "nonexistent-parent-12345");
+        docRequest.put("name", "test-document-invalid-parent.txt");
+        docRequest.put("typeId", "cmis:document");
+        
+        given()
+            .spec(requestSpec)
+            .body(docRequest)
+        .when()
+            .post(documentsPath())
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testGetCheckedOutDocuments_ReturnsOk() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(documentsPath() + "/checkedout")
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objects", notNullValue())
+            .body("hasMoreItems", notNullValue());
+    }
+    
+    @Test
+    public void testGetCheckedOutDocuments_WithPagination_ReturnsOk() {
+        given()
+            .spec(requestSpec)
+            .queryParam("maxItems", 10)
+            .queryParam("skipCount", 0)
+        .when()
+            .get(documentsPath() + "/checkedout")
+        .then()
+            .statusCode(200)
+            .body("maxItems", equalTo(10))
+            .body("skipCount", equalTo(0));
+    }
+    
+    @Test
+    public void testCheckout_InvalidDocumentId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .post(documentsPath() + "/nonexistent-doc-12345/checkout")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testCheckin_InvalidDocumentId_Returns404() {
+        Map<String, Object> checkinRequest = new HashMap<>();
+        checkinRequest.put("major", true);
+        checkinRequest.put("checkinComment", "Test checkin");
+        
+        given()
+            .spec(requestSpec)
+            .body(checkinRequest)
+        .when()
+            .post(documentsPath() + "/nonexistent-doc-12345/checkin")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testCancelCheckout_InvalidDocumentId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .post(documentsPath() + "/nonexistent-doc-12345/cancelCheckout")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testGetVersions_InvalidDocumentId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(documentsPath() + "/nonexistent-doc-12345/versions")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testGetLatestVersion_InvalidDocumentId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(documentsPath() + "/nonexistent-doc-12345/latestVersion")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testDocumentVersioningWorkflow() {
+        // This test creates a document, checks it out, checks it in, and verifies versions
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        // Create document
+        Map<String, Object> docRequest = new HashMap<>();
+        docRequest.put("parentId", rootFolderId);
+        docRequest.put("name", "versioning-test-" + System.currentTimeMillis() + ".txt");
+        docRequest.put("typeId", "cmis:document");
+        
+        Response createResponse = given()
+            .spec(requestSpec)
+            .body(docRequest)
+        .when()
+            .post(documentsPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String docId = createResponse.path("objectId");
+        
+        try {
+            // Check out
+            Response checkoutResponse = given()
+                .spec(requestSpec)
+            .when()
+                .post(documentsPath() + "/" + docId + "/checkout")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(201)))
+                .extract()
+                .response();
+            
+            String pwcId = checkoutResponse.path("objectId");
+            
+            // Check in
+            Map<String, Object> checkinRequest = new HashMap<>();
+            checkinRequest.put("major", true);
+            checkinRequest.put("checkinComment", "First major version");
+            
+            given()
+                .spec(requestSpec)
+                .body(checkinRequest)
+            .when()
+                .post(documentsPath() + "/" + pwcId + "/checkin")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(201)));
+            
+            // Get versions
+            given()
+                .spec(requestSpec)
+            .when()
+                .get(documentsPath() + "/" + docId + "/versions")
+            .then()
+                .statusCode(200)
+                .body("objects", notNullValue());
+            
+        } finally {
+            // Clean up
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(docId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/FolderResourceIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/FolderResourceIT.java
@@ -1,0 +1,261 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * E2E/Integration tests for FolderResource endpoints.
+ * 
+ * Tests the following endpoints:
+ * - POST /repositories/{repoId}/folders - Create folder
+ * - GET /repositories/{repoId}/folders/{folderId}/children - Get children
+ * - GET /repositories/{repoId}/folders/{folderId}/descendants - Get descendants
+ * - GET /repositories/{repoId}/folders/{folderId}/tree - Get folder tree
+ * - GET /repositories/{repoId}/folders/{folderId}/parent - Get parent folder
+ * - DELETE /repositories/{repoId}/folders/{folderId}/tree - Delete folder tree
+ * 
+ * Run with: mvn test -Dtest=FolderResourceIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class FolderResourceIT extends ApiV1TestBase {
+    
+    @Test
+    public void testGetChildren_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(foldersPath() + "/" + rootFolderId + "/children")
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objects", notNullValue())
+            .body("hasMoreItems", notNullValue())
+            .body("links", notNullValue());
+    }
+    
+    @Test
+    public void testGetChildren_WithPagination_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("maxItems", 10)
+            .queryParam("skipCount", 0)
+        .when()
+            .get(foldersPath() + "/" + rootFolderId + "/children")
+        .then()
+            .statusCode(200)
+            .body("maxItems", equalTo(10))
+            .body("skipCount", equalTo(0));
+    }
+    
+    @Test
+    public void testGetChildren_WithFilter_ReturnsFilteredProperties() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("filter", "cmis:name,cmis:objectTypeId")
+        .when()
+            .get(foldersPath() + "/" + rootFolderId + "/children")
+        .then()
+            .statusCode(200);
+    }
+    
+    @Test
+    public void testGetDescendants_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("depth", 1)
+        .when()
+            .get(foldersPath() + "/" + rootFolderId + "/descendants")
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objects", notNullValue());
+    }
+    
+    @Test
+    public void testGetFolderTree_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("depth", 1)
+        .when()
+            .get(foldersPath() + "/" + rootFolderId + "/tree")
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objects", notNullValue());
+    }
+    
+    @Test
+    public void testGetParent_RootFolder_ReturnsNull() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        // Root folder has no parent
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(foldersPath() + "/" + rootFolderId + "/parent")
+        .then()
+            .statusCode(anyOf(equalTo(200), equalTo(404)));
+    }
+    
+    @Test
+    public void testCreateFolder_ValidRequest_ReturnsCreated() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("parentId", rootFolderId);
+        folderRequest.put("name", "test-folder-" + System.currentTimeMillis());
+        folderRequest.put("typeId", "cmis:folder");
+        
+        Response response = given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .contentType("application/json")
+            .body("objectId", notNullValue())
+            .body("objectTypeId", equalTo("cmis:folder"))
+            .body("links", notNullValue())
+            .extract()
+            .response();
+        
+        // Clean up: delete the created folder
+        String folderId = response.path("objectId");
+        if (folderId != null) {
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(folderId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testCreateFolder_MissingParentId_Returns400() {
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("name", "test-folder-no-parent");
+        folderRequest.put("typeId", "cmis:folder");
+        
+        given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testCreateFolder_InvalidParentId_Returns404() {
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("parentId", "nonexistent-parent-12345");
+        folderRequest.put("name", "test-folder-invalid-parent");
+        folderRequest.put("typeId", "cmis:folder");
+        
+        given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testGetChildren_InvalidFolderId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(foldersPath() + "/nonexistent-folder-12345/children")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testGetChildren_ContainsHATEOASLinks() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(foldersPath() + "/" + rootFolderId + "/children")
+        .then()
+            .statusCode(200)
+            .body("links.self", notNullValue())
+            .body("links.self.href", containsString("children"));
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ODataDocumentsIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ODataDocumentsIT.java
@@ -1,0 +1,176 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.hamcrest.Matchers;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * E2E/Integration tests for OData Documents endpoints.
+ *
+ * Run with: mvn test -Dtest=ODataDocumentsIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class ODataDocumentsIT extends ODataTestBase {
+
+    @Test
+    public void testListDocuments_ReturnsOk() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath())
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testFilterStartswith_ReturnsOk() {
+        String filter = URLEncoder.encode("startswith(name,'A')", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testFilterEquals_ReturnsOk() {
+        String filter = URLEncoder.encode("name eq 'test.pdf'", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testTopSkip_Paginates() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$top=1&$skip=0")
+        .then()
+                .statusCode(200)
+                .body("value.size()", lessThanOrEqualTo(1));
+    }
+
+    @Test
+    public void testCount_ReturnsCount() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$count=true")
+        .then()
+                .statusCode(200)
+                .body("@odata.count", notNullValue());
+    }
+
+    @Test
+    public void testSelectOrderBy_ReturnsOk() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$select=objectId,name&$orderby=name")
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testCreateUpdateDelete_DocumentLifecycle() {
+        String folderId = fetchAnyFolderId();
+        String name = "odata-doc-" + System.currentTimeMillis();
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("name", name);
+        payload.put("objectTypeId", "cmis:document");
+        payload.put("folderId", folderId);
+
+        Response createResponse = given()
+                .spec(odataRequestSpec)
+                .body(payload)
+        .when()
+                .post(odataDocumentsPath())
+        .then()
+                .statusCode(anyOf(equalTo(200), equalTo(201)))
+                .extract()
+                .response();
+
+        String documentId = extractObjectId(createResponse);
+        assertThat(documentId, notNullValue());
+
+        Map<String, Object> updatePayload = new HashMap<>();
+        updatePayload.put("name", name + "-updated");
+
+        given()
+                .spec(odataRequestSpec)
+                .header("If-Match", "*")
+                .body(updatePayload)
+        .when()
+                .patch(odataDocumentsPath() + "('" + documentId + "')")
+        .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "('" + documentId + "')")
+        .then()
+                .statusCode(200)
+                .body("objectId", Matchers.anyOf(equalTo(documentId), notNullValue()));
+
+        given()
+                .spec(odataRequestSpec)
+                .header("If-Match", "*")
+        .when()
+                .delete(odataDocumentsPath() + "('" + documentId + "')")
+        .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+    }
+
+    private String fetchAnyFolderId() {
+        Response response = given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$top=1")
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue())
+                .extract()
+                .response();
+
+        String objectId = response.jsonPath().getString("value[0].objectId");
+        if (objectId == null) {
+            objectId = response.jsonPath().getString("value[0].id");
+        }
+        assertThat(objectId, notNullValue());
+        return objectId;
+    }
+
+    private String extractObjectId(Response response) {
+        String objectId = response.jsonPath().getString("objectId");
+        if (objectId == null) {
+            objectId = response.jsonPath().getString("id");
+        }
+        return objectId;
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ODataDocumentsIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ODataDocumentsIT.java
@@ -63,6 +63,45 @@ public class ODataDocumentsIT extends ODataTestBase {
     }
 
     @Test
+    public void testFilterContains_ReturnsOk() {
+        String filter = URLEncoder.encode("contains(name,'test')", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testFilterEndswith_ReturnsOk() {
+        String filter = URLEncoder.encode("endswith(name,'.pdf')", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testFilterCompoundAndOr_ReturnsOk() {
+        String filter = URLEncoder.encode("name eq 'test.pdf' or contains(name,'draft')", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataDocumentsPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
     public void testTopSkip_Paginates() {
         given()
                 .spec(odataRequestSpec)

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ODataFoldersIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ODataFoldersIT.java
@@ -1,0 +1,162 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * E2E/Integration tests for OData Folders endpoints.
+ *
+ * Run with: mvn test -Dtest=ODataFoldersIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class ODataFoldersIT extends ODataTestBase {
+
+    @Test
+    public void testListFolders_ReturnsOk() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath())
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testFilterStartswith_ReturnsOk() {
+        String filter = URLEncoder.encode("startswith(name,'A')", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testTopSkip_Paginates() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$top=1&$skip=0")
+        .then()
+                .statusCode(200)
+                .body("value.size()", lessThanOrEqualTo(1));
+    }
+
+    @Test
+    public void testCount_ReturnsCount() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$count=true")
+        .then()
+                .statusCode(200)
+                .body("@odata.count", notNullValue());
+    }
+
+    @Test
+    public void testSelectOrderBy_ReturnsOk() {
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$select=objectId,name&$orderby=name")
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testCreateUpdateDelete_FolderLifecycle() {
+        String parentId = fetchAnyFolderId();
+        String name = "odata-folder-" + System.currentTimeMillis();
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("name", name);
+        payload.put("objectTypeId", "cmis:folder");
+        payload.put("parentId", parentId);
+
+        Response createResponse = given()
+                .spec(odataRequestSpec)
+                .body(payload)
+        .when()
+                .post(odataFoldersPath())
+        .then()
+                .statusCode(anyOf(equalTo(200), equalTo(201)))
+                .extract()
+                .response();
+
+        String folderId = extractObjectId(createResponse);
+        assertThat(folderId, notNullValue());
+
+        Map<String, Object> updatePayload = new HashMap<>();
+        updatePayload.put("name", name + "-updated");
+
+        given()
+                .spec(odataRequestSpec)
+                .header("If-Match", "*")
+                .body(updatePayload)
+        .when()
+                .patch(odataFoldersPath() + "('" + folderId + "')")
+        .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "('" + folderId + "')")
+        .then()
+                .statusCode(200)
+                .body("objectId", notNullValue());
+
+        given()
+                .spec(odataRequestSpec)
+                .header("If-Match", "*")
+        .when()
+                .delete(odataFoldersPath() + "('" + folderId + "')")
+        .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+    }
+
+    private String fetchAnyFolderId() {
+        Response response = given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$top=1")
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue())
+                .extract()
+                .response();
+
+        String objectId = response.jsonPath().getString("value[0].objectId");
+        if (objectId == null) {
+            objectId = response.jsonPath().getString("value[0].id");
+        }
+        assertThat(objectId, notNullValue());
+        return objectId;
+    }
+
+    private String extractObjectId(Response response) {
+        String objectId = response.jsonPath().getString("objectId");
+        if (objectId == null) {
+            objectId = response.jsonPath().getString("id");
+        }
+        return objectId;
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ODataFoldersIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ODataFoldersIT.java
@@ -49,6 +49,32 @@ public class ODataFoldersIT extends ODataTestBase {
     }
 
     @Test
+    public void testFilterContains_ReturnsOk() {
+        String filter = URLEncoder.encode("contains(name,'folder')", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
+    public void testFilterEndswith_ReturnsOk() {
+        String filter = URLEncoder.encode("endswith(name,'s')", StandardCharsets.UTF_8);
+
+        given()
+                .spec(odataRequestSpec)
+        .when()
+                .get(odataFoldersPath() + "?$filter=" + filter)
+        .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test
     public void testTopSkip_Paginates() {
         given()
                 .spec(odataRequestSpec)

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ODataTestBase.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ODataTestBase.java
@@ -1,0 +1,47 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.junit.BeforeClass;
+
+/**
+ * Base class for OData E2E/integration tests using REST Assured.
+ *
+ * Tests are designed to run against a deployed NemakiWare instance.
+ */
+public abstract class ODataTestBase extends ApiV1TestBase {
+
+    protected static final String ODATA_PATH = "/odata";
+
+    protected static RequestSpecification odataRequestSpec;
+
+    @BeforeClass
+    public static void setupODataRestAssured() {
+        baseUrl = getConfigValue("nemaki.test.baseUrl", "NEMAKI_TEST_BASE_URL", "http://localhost:8080/core");
+        username = getConfigValue("nemaki.test.username", "NEMAKI_TEST_USERNAME", "admin");
+        password = getConfigValue("nemaki.test.password", "NEMAKI_TEST_PASSWORD", "admin");
+        repositoryId = getConfigValue("nemaki.test.repositoryId", "NEMAKI_TEST_REPOSITORY_ID", "bedroom");
+
+        RestAssured.baseURI = baseUrl;
+        RestAssured.basePath = ODATA_PATH;
+
+        odataRequestSpec = new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setAccept(ContentType.JSON)
+                .addHeader("Authorization", createBasicAuthHeader(username, password))
+                .log(LogDetail.METHOD)
+                .log(LogDetail.URI)
+                .build();
+    }
+
+    protected String odataDocumentsPath() {
+        return "/" + repositoryId + "/Documents";
+    }
+
+    protected String odataFoldersPath() {
+        return "/" + repositoryId + "/Folders";
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/ObjectResourceIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/ObjectResourceIT.java
@@ -1,0 +1,239 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * E2E/Integration tests for ObjectResource endpoints.
+ * 
+ * Tests the following endpoints:
+ * - GET /repositories/{repoId}/objects/{objectId} - Get object
+ * - DELETE /repositories/{repoId}/objects/{objectId} - Delete object
+ * - GET /repositories/{repoId}/objects/{objectId}/content - Get content stream
+ * - PUT /repositories/{repoId}/objects/{objectId}/content - Set content stream
+ * - DELETE /repositories/{repoId}/objects/{objectId}/content - Delete content stream
+ * - POST /repositories/{repoId}/objects/{objectId}/content/append - Append content
+ * - POST /repositories/{repoId}/objects/{objectId}/move - Move object
+ * - GET /repositories/{repoId}/objects/{objectId}/parents - Get parents
+ * - GET /repositories/{repoId}/objects/{objectId}/relationships - Get relationships
+ * - GET /repositories/{repoId}/objects/{objectId}/allowableActions - Get allowable actions
+ * - GET /repositories/{repoId}/objects/{objectId}/renditions - Get renditions
+ * 
+ * Run with: mvn test -Dtest=ObjectResourceIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class ObjectResourceIT extends ApiV1TestBase {
+    
+    @Test
+    public void testGetObject_RootFolder_ReturnsOk() {
+        // First get the root folder ID from repository info
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .statusCode(200)
+            .extract()
+            .path("rootFolderId");
+        
+        // Then get the root folder object
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objectId", equalTo(rootFolderId))
+            .body("objectTypeId", notNullValue())
+            .body("properties", notNullValue())
+            .body("links", notNullValue());
+    }
+    
+    @Test
+    public void testGetObject_WithFilter_ReturnsFilteredProperties() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("filter", "cmis:name,cmis:objectTypeId")
+        .when()
+            .get(objectPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .body("properties.cmis:name", notNullValue())
+            .body("properties.cmis:objectTypeId", notNullValue());
+    }
+    
+    @Test
+    public void testGetObject_InvalidObjectId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath("nonexistent-object-12345"))
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(404))
+            .body("detail", notNullValue());
+    }
+    
+    @Test
+    public void testGetAllowableActions_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId) + "/allowableActions")
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objectId", equalTo(rootFolderId))
+            .body("allowableActions", notNullValue())
+            .body("links", notNullValue());
+    }
+    
+    @Test
+    public void testGetAllowableActions_ContainsExpectedActions() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId) + "/allowableActions")
+        .then()
+            .statusCode(200)
+            .body("allowableActions.canGetProperties", notNullValue())
+            .body("allowableActions.canGetChildren", notNullValue())
+            .body("allowableActions.canCreateDocument", notNullValue())
+            .body("allowableActions.canCreateFolder", notNullValue());
+    }
+    
+    @Test
+    public void testGetParents_RootFolder_ReturnsEmptyList() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId) + "/parents")
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objects", empty());
+    }
+    
+    @Test
+    public void testGetRenditions_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId) + "/renditions")
+        .then()
+            .statusCode(200)
+            .contentType("application/json");
+    }
+    
+    @Test
+    public void testGetRelationships_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId) + "/relationships")
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objects", notNullValue());
+    }
+    
+    @Test
+    public void testGetObject_PropertyStructure_Has2LayerFormat() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        // Verify 2-layer property structure (value/type)
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .body("properties.cmis:name.value", notNullValue())
+            .body("properties.cmis:name.type", equalTo("string"))
+            .body("properties.cmis:objectTypeId.value", notNullValue())
+            .body("properties.cmis:objectTypeId.type", equalTo("id"));
+    }
+    
+    @Test
+    public void testGetObject_LinksContainHATEOAS() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(objectPath(rootFolderId))
+        .then()
+            .statusCode(200)
+            .body("links.self", notNullValue())
+            .body("links.self.href", containsString(rootFolderId))
+            .body("links.allowableActions", notNullValue())
+            .body("links.acl", notNullValue());
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/PolicyResourceIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/PolicyResourceIT.java
@@ -1,0 +1,503 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * E2E/Integration tests for PolicyResource endpoints.
+ * 
+ * Tests the following endpoints:
+ * - POST /repositories/{repoId}/policies - Create policy
+ * - POST /repositories/{repoId}/policies/apply - Apply policy to object
+ * - POST /repositories/{repoId}/policies/remove - Remove policy from object
+ * - GET /repositories/{repoId}/policies/object/{objectId} - Get applied policies
+ * 
+ * Run with: mvn test -Dtest=PolicyResourceIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class PolicyResourceIT extends ApiV1TestBase {
+    
+    @Test
+    public void testGetAppliedPolicies_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(policiesPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objectId", equalTo(rootFolderId))
+            .body("policies", notNullValue())
+            .body("numPolicies", notNullValue())
+            .body("links", notNullValue());
+    }
+    
+    @Test
+    public void testGetAppliedPolicies_InvalidObjectId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(policiesPath() + "/object/nonexistent-object-12345")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testCreatePolicy_ValidRequest_ReturnsCreated() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> policyRequest = new HashMap<>();
+        policyRequest.put("name", "test-policy-" + System.currentTimeMillis());
+        policyRequest.put("typeId", "cmis:policy");
+        policyRequest.put("folderId", rootFolderId);
+        policyRequest.put("policyText", "Test policy text");
+        
+        Response response = given()
+            .spec(requestSpec)
+            .body(policyRequest)
+        .when()
+            .post(policiesPath())
+        .then()
+            .statusCode(anyOf(equalTo(201), equalTo(200)))
+            .contentType("application/json")
+            .body("objectId", notNullValue())
+            .body("links", notNullValue())
+            .extract()
+            .response();
+        
+        // Clean up: delete the created policy
+        String policyId = response.path("objectId");
+        if (policyId != null) {
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(policyId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testCreatePolicy_MissingName_Returns400() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> policyRequest = new HashMap<>();
+        policyRequest.put("typeId", "cmis:policy");
+        policyRequest.put("folderId", rootFolderId);
+        
+        given()
+            .spec(requestSpec)
+            .body(policyRequest)
+        .when()
+            .post(policiesPath())
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testApplyPolicy_ValidRequest_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        // Create a policy first
+        Map<String, Object> policyRequest = new HashMap<>();
+        policyRequest.put("name", "apply-test-policy-" + System.currentTimeMillis());
+        policyRequest.put("typeId", "cmis:policy");
+        policyRequest.put("folderId", rootFolderId);
+        policyRequest.put("policyText", "Test policy for apply");
+        
+        Response policyResponse = given()
+            .spec(requestSpec)
+            .body(policyRequest)
+        .when()
+            .post(policiesPath())
+        .then()
+            .statusCode(anyOf(equalTo(201), equalTo(200)))
+            .extract()
+            .response();
+        
+        String policyId = policyResponse.path("objectId");
+        
+        // Create a test folder to apply policy to
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("parentId", rootFolderId);
+        folderRequest.put("name", "policy-target-folder-" + System.currentTimeMillis());
+        folderRequest.put("typeId", "cmis:folder");
+        
+        Response folderResponse = given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String folderId = folderResponse.path("objectId");
+        
+        try {
+            // Apply policy
+            Map<String, Object> applyRequest = new HashMap<>();
+            applyRequest.put("policyId", policyId);
+            applyRequest.put("objectId", folderId);
+            
+            given()
+                .spec(requestSpec)
+                .body(applyRequest)
+            .when()
+                .post(policiesPath() + "/apply")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(201)))
+                .contentType("application/json");
+            
+            // Verify policy is applied
+            given()
+                .spec(requestSpec)
+            .when()
+                .get(policiesPath() + "/object/" + folderId)
+            .then()
+                .statusCode(200)
+                .body("policies", notNullValue());
+            
+        } finally {
+            // Clean up
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(folderId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+            
+            if (policyId != null) {
+                given()
+                    .spec(requestSpec)
+                .when()
+                    .delete(objectPath(policyId))
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            }
+        }
+    }
+    
+    @Test
+    public void testApplyPolicy_MissingPolicyId_Returns400() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> applyRequest = new HashMap<>();
+        applyRequest.put("objectId", rootFolderId);
+        
+        given()
+            .spec(requestSpec)
+            .body(applyRequest)
+        .when()
+            .post(policiesPath() + "/apply")
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testApplyPolicy_MissingObjectId_Returns400() {
+        Map<String, Object> applyRequest = new HashMap<>();
+        applyRequest.put("policyId", "some-policy-id");
+        
+        given()
+            .spec(requestSpec)
+            .body(applyRequest)
+        .when()
+            .post(policiesPath() + "/apply")
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testApplyPolicy_InvalidPolicyId_Returns404() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> applyRequest = new HashMap<>();
+        applyRequest.put("policyId", "nonexistent-policy-12345");
+        applyRequest.put("objectId", rootFolderId);
+        
+        given()
+            .spec(requestSpec)
+            .body(applyRequest)
+        .when()
+            .post(policiesPath() + "/apply")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testApplyPolicy_InvalidObjectId_Returns404() {
+        // This test assumes there's at least one policy in the system
+        // If not, it will return 404 for the policy, which is also acceptable
+        Map<String, Object> applyRequest = new HashMap<>();
+        applyRequest.put("policyId", "some-policy-id");
+        applyRequest.put("objectId", "nonexistent-object-12345");
+        
+        given()
+            .spec(requestSpec)
+            .body(applyRequest)
+        .when()
+            .post(policiesPath() + "/apply")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testRemovePolicy_MissingPolicyId_Returns400() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> removeRequest = new HashMap<>();
+        removeRequest.put("objectId", rootFolderId);
+        
+        given()
+            .spec(requestSpec)
+            .body(removeRequest)
+        .when()
+            .post(policiesPath() + "/remove")
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testRemovePolicy_MissingObjectId_Returns400() {
+        Map<String, Object> removeRequest = new HashMap<>();
+        removeRequest.put("policyId", "some-policy-id");
+        
+        given()
+            .spec(requestSpec)
+            .body(removeRequest)
+        .when()
+            .post(policiesPath() + "/remove")
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testRemovePolicy_InvalidPolicyId_Returns404() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> removeRequest = new HashMap<>();
+        removeRequest.put("policyId", "nonexistent-policy-12345");
+        removeRequest.put("objectId", rootFolderId);
+        
+        given()
+            .spec(requestSpec)
+            .body(removeRequest)
+        .when()
+            .post(policiesPath() + "/remove")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testGetAppliedPolicies_ContainsHATEOASLinks() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(policiesPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .body("links.self", notNullValue())
+            .body("links.self.href", containsString("policies"))
+            .body("links.object", notNullValue());
+    }
+    
+    @Test
+    public void testPolicyWorkflow_CreateApplyRemove() {
+        // This test creates a policy, applies it to an object, verifies it's applied,
+        // removes it, and verifies it's removed
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        // Create policy
+        Map<String, Object> policyRequest = new HashMap<>();
+        policyRequest.put("name", "workflow-test-policy-" + System.currentTimeMillis());
+        policyRequest.put("typeId", "cmis:policy");
+        policyRequest.put("folderId", rootFolderId);
+        policyRequest.put("policyText", "Workflow test policy");
+        
+        Response policyResponse = given()
+            .spec(requestSpec)
+            .body(policyRequest)
+        .when()
+            .post(policiesPath())
+        .then()
+            .statusCode(anyOf(equalTo(201), equalTo(200)))
+            .extract()
+            .response();
+        
+        String policyId = policyResponse.path("objectId");
+        
+        // Create target folder
+        Map<String, Object> folderRequest = new HashMap<>();
+        folderRequest.put("parentId", rootFolderId);
+        folderRequest.put("name", "workflow-target-" + System.currentTimeMillis());
+        folderRequest.put("typeId", "cmis:folder");
+        
+        Response folderResponse = given()
+            .spec(requestSpec)
+            .body(folderRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String folderId = folderResponse.path("objectId");
+        
+        try {
+            // Apply policy
+            Map<String, Object> applyRequest = new HashMap<>();
+            applyRequest.put("policyId", policyId);
+            applyRequest.put("objectId", folderId);
+            
+            given()
+                .spec(requestSpec)
+                .body(applyRequest)
+            .when()
+                .post(policiesPath() + "/apply")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(201)));
+            
+            // Verify policy is applied
+            given()
+                .spec(requestSpec)
+            .when()
+                .get(policiesPath() + "/object/" + folderId)
+            .then()
+                .statusCode(200)
+                .body("policies", notNullValue());
+            
+            // Remove policy
+            Map<String, Object> removeRequest = new HashMap<>();
+            removeRequest.put("policyId", policyId);
+            removeRequest.put("objectId", folderId);
+            
+            given()
+                .spec(requestSpec)
+                .body(removeRequest)
+            .when()
+                .post(policiesPath() + "/remove")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+            
+            // Verify policy is removed
+            given()
+                .spec(requestSpec)
+            .when()
+                .get(policiesPath() + "/object/" + folderId)
+            .then()
+                .statusCode(200);
+            
+        } finally {
+            // Clean up
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(folderId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+            
+            if (policyId != null) {
+                given()
+                    .spec(requestSpec)
+                .when()
+                    .delete(objectPath(policyId))
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            }
+        }
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/RelationshipResourceIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/RelationshipResourceIT.java
@@ -1,0 +1,372 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * E2E/Integration tests for RelationshipResource endpoints.
+ * 
+ * Tests the following endpoints:
+ * - POST /repositories/{repoId}/relationships - Create relationship
+ * - GET /repositories/{repoId}/relationships/object/{objectId} - Get relationships for object
+ * 
+ * Run with: mvn test -Dtest=RelationshipResourceIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class RelationshipResourceIT extends ApiV1TestBase {
+    
+    @Test
+    public void testGetObjectRelationships_RootFolder_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(relationshipsPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("objects", notNullValue())
+            .body("hasMoreItems", notNullValue())
+            .body("links", notNullValue());
+    }
+    
+    @Test
+    public void testGetObjectRelationships_WithPagination_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("maxItems", 10)
+            .queryParam("skipCount", 0)
+        .when()
+            .get(relationshipsPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .body("maxItems", equalTo(10))
+            .body("skipCount", equalTo(0));
+    }
+    
+    @Test
+    public void testGetObjectRelationships_WithSourceDirection_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("relationshipDirection", "source")
+        .when()
+            .get(relationshipsPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .body("objects", notNullValue());
+    }
+    
+    @Test
+    public void testGetObjectRelationships_WithTargetDirection_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("relationshipDirection", "target")
+        .when()
+            .get(relationshipsPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .body("objects", notNullValue());
+    }
+    
+    @Test
+    public void testGetObjectRelationships_WithEitherDirection_ReturnsOk() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+            .queryParam("relationshipDirection", "either")
+        .when()
+            .get(relationshipsPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .body("objects", notNullValue());
+    }
+    
+    @Test
+    public void testGetObjectRelationships_InvalidObjectId_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(relationshipsPath() + "/object/nonexistent-object-12345")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testCreateRelationship_ValidRequest_ReturnsCreated() {
+        // First create two test objects (folders) to create a relationship between
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        // Create source folder
+        Map<String, Object> sourceRequest = new HashMap<>();
+        sourceRequest.put("parentId", rootFolderId);
+        sourceRequest.put("name", "rel-source-" + System.currentTimeMillis());
+        sourceRequest.put("typeId", "cmis:folder");
+        
+        Response sourceResponse = given()
+            .spec(requestSpec)
+            .body(sourceRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String sourceId = sourceResponse.path("objectId");
+        
+        // Create target folder
+        Map<String, Object> targetRequest = new HashMap<>();
+        targetRequest.put("parentId", rootFolderId);
+        targetRequest.put("name", "rel-target-" + System.currentTimeMillis());
+        targetRequest.put("typeId", "cmis:folder");
+        
+        Response targetResponse = given()
+            .spec(requestSpec)
+            .body(targetRequest)
+        .when()
+            .post(foldersPath())
+        .then()
+            .statusCode(201)
+            .extract()
+            .response();
+        
+        String targetId = targetResponse.path("objectId");
+        
+        try {
+            // Create relationship
+            Map<String, Object> relRequest = new HashMap<>();
+            relRequest.put("sourceId", sourceId);
+            relRequest.put("targetId", targetId);
+            relRequest.put("typeId", "cmis:relationship");
+            
+            Response relResponse = given()
+                .spec(requestSpec)
+                .body(relRequest)
+            .when()
+                .post(relationshipsPath())
+            .then()
+                .statusCode(anyOf(equalTo(201), equalTo(200)))
+                .contentType("application/json")
+                .body("objectId", notNullValue())
+                .body("sourceId", equalTo(sourceId))
+                .body("targetId", equalTo(targetId))
+                .body("links", notNullValue())
+                .extract()
+                .response();
+            
+            // Verify relationship appears in source's relationships
+            given()
+                .spec(requestSpec)
+                .queryParam("relationshipDirection", "source")
+            .when()
+                .get(relationshipsPath() + "/object/" + sourceId)
+            .then()
+                .statusCode(200)
+                .body("objects", notNullValue());
+            
+            // Clean up relationship if created
+            String relId = relResponse.path("objectId");
+            if (relId != null) {
+                given()
+                    .spec(requestSpec)
+                .when()
+                    .delete(objectPath(relId))
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            }
+            
+        } finally {
+            // Clean up source and target folders
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(sourceId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+            
+            given()
+                .spec(requestSpec)
+            .when()
+                .delete(objectPath(targetId))
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+    
+    @Test
+    public void testCreateRelationship_MissingSourceId_Returns400() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> relRequest = new HashMap<>();
+        relRequest.put("targetId", rootFolderId);
+        relRequest.put("typeId", "cmis:relationship");
+        
+        given()
+            .spec(requestSpec)
+            .body(relRequest)
+        .when()
+            .post(relationshipsPath())
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testCreateRelationship_MissingTargetId_Returns400() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> relRequest = new HashMap<>();
+        relRequest.put("sourceId", rootFolderId);
+        relRequest.put("typeId", "cmis:relationship");
+        
+        given()
+            .spec(requestSpec)
+            .body(relRequest)
+        .when()
+            .post(relationshipsPath())
+        .then()
+            .statusCode(400)
+            .contentType("application/problem+json")
+            .body("status", equalTo(400));
+    }
+    
+    @Test
+    public void testCreateRelationship_InvalidSourceId_Returns404() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> relRequest = new HashMap<>();
+        relRequest.put("sourceId", "nonexistent-source-12345");
+        relRequest.put("targetId", rootFolderId);
+        relRequest.put("typeId", "cmis:relationship");
+        
+        given()
+            .spec(requestSpec)
+            .body(relRequest)
+        .when()
+            .post(relationshipsPath())
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testCreateRelationship_InvalidTargetId_Returns404() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        Map<String, Object> relRequest = new HashMap<>();
+        relRequest.put("sourceId", rootFolderId);
+        relRequest.put("targetId", "nonexistent-target-12345");
+        relRequest.put("typeId", "cmis:relationship");
+        
+        given()
+            .spec(requestSpec)
+            .body(relRequest)
+        .when()
+            .post(relationshipsPath())
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", equalTo(404));
+    }
+    
+    @Test
+    public void testGetObjectRelationships_ContainsHATEOASLinks() {
+        String rootFolderId = given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .extract()
+            .path("rootFolderId");
+        
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(relationshipsPath() + "/object/" + rootFolderId)
+        .then()
+            .statusCode(200)
+            .body("links.self", notNullValue())
+            .body("links.self.href", containsString("relationships"));
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/RepositoryResourceIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/RepositoryResourceIT.java
@@ -1,0 +1,129 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * E2E/Integration tests for RepositoryResource endpoints.
+ * 
+ * Tests the following endpoints:
+ * - GET /repositories - List all repositories
+ * - GET /repositories/{repositoryId} - Get repository info
+ * 
+ * Run with: mvn test -Dtest=RepositoryResourceIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class RepositoryResourceIT extends ApiV1TestBase {
+    
+    @Test
+    public void testListRepositories_ReturnsOk() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoriesPath())
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("repositories", notNullValue())
+            .body("repositories", not(empty()));
+    }
+    
+    @Test
+    public void testListRepositories_ContainsRepositoryId() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoriesPath())
+        .then()
+            .statusCode(200)
+            .body("repositories.repositoryId", hasItem(repositoryId));
+    }
+    
+    @Test
+    public void testGetRepositoryInfo_ReturnsOk() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("repositoryId", equalTo(repositoryId))
+            .body("repositoryName", notNullValue())
+            .body("rootFolderId", notNullValue())
+            .body("cmisVersionSupported", notNullValue());
+    }
+    
+    @Test
+    public void testGetRepositoryInfo_ContainsCapabilities() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .statusCode(200)
+            .body("capabilities", notNullValue())
+            .body("capabilities.capabilityContentStreamUpdatability", notNullValue())
+            .body("capabilities.capabilityChanges", notNullValue())
+            .body("capabilities.capabilityRenditions", notNullValue());
+    }
+    
+    @Test
+    public void testGetRepositoryInfo_ContainsAclCapability() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .statusCode(200)
+            .body("aclCapability", notNullValue())
+            .body("aclCapability.supportedPermissions", notNullValue())
+            .body("aclCapability.propagation", notNullValue());
+    }
+    
+    @Test
+    public void testGetRepositoryInfo_ContainsLinks() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get(repositoryPath())
+        .then()
+            .statusCode(200)
+            .body("links", notNullValue())
+            .body("links.self", notNullValue())
+            .body("links.self.href", containsString(repositoryId));
+    }
+    
+    @Test
+    public void testGetRepositoryInfo_InvalidRepository_Returns404() {
+        given()
+            .spec(requestSpec)
+        .when()
+            .get("/repositories/nonexistent-repo-12345")
+        .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("title", notNullValue())
+            .body("status", equalTo(404))
+            .body("detail", notNullValue());
+    }
+    
+    @Test
+    public void testListRepositories_Unauthenticated_Returns401() {
+        given()
+            .contentType("application/json")
+            .accept("application/json")
+        .when()
+            .get(repositoriesPath())
+        .then()
+            .statusCode(401)
+            .contentType("application/problem+json")
+            .body("type", containsString("/errors/"))
+            .body("status", equalTo(401));
+    }
+}

--- a/core/src/test/java/jp/aegif/nemaki/api/v1/RoutingRegressionIT.java
+++ b/core/src/test/java/jp/aegif/nemaki/api/v1/RoutingRegressionIT.java
@@ -1,0 +1,63 @@
+package jp.aegif.nemaki.api.v1;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Regression tests to ensure CMIS API and legacy API routes coexist.
+ *
+ * Run with: mvn test -Dtest=RoutingRegressionIT -Dnemaki.test.baseUrl=http://localhost:8080/core
+ */
+@Ignore("Integration tests require a running NemakiWare instance")
+public class RoutingRegressionIT extends ApiV1TestBase {
+
+    @BeforeClass
+    public static void setupRoutingRestAssured() {
+        baseUrl = getConfigValue("nemaki.test.baseUrl", "NEMAKI_TEST_BASE_URL", "http://localhost:8080/core");
+        username = getConfigValue("nemaki.test.username", "NEMAKI_TEST_USERNAME", "admin");
+        password = getConfigValue("nemaki.test.password", "NEMAKI_TEST_PASSWORD", "admin");
+        repositoryId = getConfigValue("nemaki.test.repositoryId", "NEMAKI_TEST_REPOSITORY_ID", "bedroom");
+
+        RestAssured.baseURI = baseUrl;
+        RestAssured.basePath = "";
+
+        requestSpec = new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setAccept(ContentType.JSON)
+                .addHeader("Authorization", createBasicAuthHeader(username, password))
+                .log(LogDetail.METHOD)
+                .log(LogDetail.URI)
+                .build();
+    }
+
+    @Test
+    public void testCmisApiRouting_ReturnsOk() {
+        given()
+                .spec(requestSpec)
+        .when()
+                .get("/api/v1/cmis/repositories")
+        .then()
+                .statusCode(200)
+                .body("repositories", notNullValue());
+    }
+
+    @Test
+    public void testLegacyApiRouting_ReturnsOk() {
+        given()
+                .spec(requestSpec)
+        .when()
+                .get("/api/v1/repo/" + repositoryId + "/users")
+        .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+    }
+}

--- a/docs/design/REST-API-ODATA-DESIGN.md
+++ b/docs/design/REST-API-ODATA-DESIGN.md
@@ -1,0 +1,1300 @@
+# NemakiWare OpenAPI REST API & OData 設計書
+
+## 1. 概要
+
+本設計書は、NemakiWare 3.0.0 の次期リリースにおける OpenAPI 準拠 REST API の拡充と OData 4.0 対応の詳細設計を記述します。
+
+### 1.1 背景
+
+現在の NemakiWare は以下の API を提供しています：
+
+1. **CMIS 1.1 バインディング** - AtomPub バインディング (`/atom/`) と Browser バインディング (`/browser/`)
+2. **独自 REST API** (`/rest/`) - CMIS にない操作（ユーザー管理、グループ管理、タイプ管理など）
+
+本設計では、CMIS の全機能を OpenAPI 準拠の REST API として公開し、さらに OData 4.0 プロトコルによるデータアクセスを可能にします。
+
+### 1.2 設計目標
+
+1. **OpenAPI 3.0 準拠**: 完全なドキュメント化された REST API の提供
+2. **CMIS 全機能の REST 化**: CMIS バインディングでのみ利用可能だった操作を REST API として公開
+3. **OData 4.0 対応**: 標準的なクエリ機能によるコンテンツ検索・ナビゲーション
+4. **後方互換性**: 既存の REST エンドポイントの維持
+5. **セキュリティ**: 適切な認証・認可の実装
+
+### 1.3 対象バージョン
+
+- ベースブランチ: `release/3.0.0-RC1-QA`
+- ターゲットリリース: 3.1.0 または 4.0.0
+
+---
+
+## 2. 現状分析
+
+### 2.1 既存 REST API エンドポイント
+
+現在の `/rest/` パス配下で提供されている API：
+
+| カテゴリ | パス | 機能 |
+|---------|------|------|
+| ユーザー管理 | `/rest/repo/{repositoryId}/user/` | CRUD、検索、パスワード変更 |
+| グループ管理 | `/rest/repo/{repositoryId}/group/` | CRUD、メンバー管理 |
+| タイプ管理 | `/rest/repo/{repositoryId}/type/` | CRUD、XML/JSON インポート |
+| アーカイブ | `/rest/repo/{repositoryId}/archive/` | 一覧、復元、完全削除 |
+| ACL | `/rest/repo/{repositoryId}/node/{objectId}/acl` | 取得、設定 |
+| 認証 | `/rest/repo/{repositoryId}/authtoken/` | トークン発行、SAML/OIDC 連携 |
+| キャッシュ | `/rest/repo/{repositoryId}/cache/` | キャッシュ無効化 |
+| 検索エンジン | `/rest/repo/{repositoryId}/search-engine/` | Solr 管理、再インデックス |
+| レンディション | `/rest/repo/{repositoryId}/renditions/` | PDF 変換、取得 |
+| リポジトリ | `/rest/all/repositories` | リポジトリ一覧 |
+
+### 2.2 CMIS サービス（REST 未公開）
+
+現在 CMIS バインディングでのみ利用可能な操作：
+
+#### ObjectService
+- `create`, `createDocument`, `createFolder`, `createRelationship`, `createPolicy`, `createItem`
+- `getObject`, `getObjectByPath`
+- `updateProperties`, `bulkUpdateProperties`
+- `deleteObject`, `deleteTree`
+- `moveObject`
+- `setContentStream`, `deleteContentStream`, `appendContentStream`
+- `getContentStream`
+- `getRenditions`
+- `getAllowableActions`
+
+#### NavigationService
+- `getChildren`
+- `getDescendants`
+- `getFolderParent`
+- `getObjectParents`
+- `getCheckedOutDocs`
+
+#### RepositoryService
+- `getRepositoryInfo`, `getRepositoryInfos`
+- `getTypeChildren`, `getTypeDescendants`
+- `getTypeDefinition`
+- `createType`, `updateType`, `deleteType`
+
+#### AclService
+- `getAcl`
+- `applyAcl`
+
+#### VersioningService
+- `checkOut`, `cancelCheckOut`, `checkIn`
+- `getAllVersions`
+- `getObjectOfLatestVersion`
+
+#### DiscoveryService
+- `query`
+- `getContentChanges`
+
+#### RelationshipService
+- `getObjectRelationships`
+
+#### PolicyService
+- `applyPolicy`, `removePolicy`
+- `getAppliedPolicies`
+
+---
+
+## 3. OpenAPI REST API 設計
+
+### 3.1 URL 構造
+
+```
+/api/v1/                           # 新規 OpenAPI 準拠 REST API
+/rest/                             # 既存 REST API（後方互換性維持）
+/odata/{repositoryId}/             # OData エンドポイント
+/atom/{repositoryId}/              # CMIS AtomPub バインディング（既存）
+/browser/{repositoryId}/           # CMIS Browser バインディング（既存）
+```
+
+### 3.2 リソース設計方針
+
+#### 3.2.1 Object/Document/Folder の境界設計
+
+CMIS では全てのコンテンツが「オブジェクト」として扱われますが、REST API では以下の方針で設計します：
+
+**設計原則:**
+- `/objects/{id}` を**正規（canonical）エンドポイント**として、任意のオブジェクトにアクセス可能
+- `/documents` と `/folders` は**便宜的なエンドポイント**として、以下の用途に限定：
+  - 作成操作（POST）: タイプ固有のバリデーションと簡略化されたリクエスト
+  - タイプ固有操作: チェックアウト/チェックインは `/documents` のみ
+  - 検索/一覧: タイプでフィルタされた結果の取得
+
+**使い分けガイドライン:**
+
+| 操作 | 推奨エンドポイント | 理由 |
+|------|-------------------|------|
+| 任意オブジェクト取得 | `/objects/{id}` | タイプに依存しない汎用アクセス |
+| ドキュメント作成 | `/documents` | バージョニング状態の指定が必要 |
+| フォルダ作成 | `/folders` | 親フォルダの指定が必須 |
+| チェックアウト/チェックイン | `/documents/{id}/checkout` | ドキュメント固有操作 |
+| プロパティ更新 | `/objects/{id}` | タイプに依存しない |
+| コンテンツ取得/更新 | `/objects/{id}/content` | タイプに依存しない |
+
+### 3.3 プロパティの型表現（動的プロパティ対応）
+
+#### 3.3.1 課題
+
+CMIS の型定義は動的であり、カスタムタイプごとにプロパティが異なります。OpenAPI のスキーマは静的であるため、`additionalProperties: true` を使用すると型情報が失われ、SDK 生成の価値が低下します。
+
+#### 3.3.2 解決策：2層構造プロパティ表現
+
+プロパティを `value` と `type` を含む構造化オブジェクトとして表現します：
+
+```json
+{
+  "objectId": "OBJECT_ID",
+  "objectTypeId": "custom:invoice",
+  "baseTypeId": "cmis:document",
+  "properties": {
+    "cmis:name": {
+      "value": "invoice-2026-001.pdf",
+      "type": "string",
+      "displayName": "Name"
+    },
+    "cmis:creationDate": {
+      "value": "2026-01-19T10:00:00Z",
+      "type": "datetime",
+      "displayName": "Creation Date"
+    },
+    "cmis:contentStreamLength": {
+      "value": 12345,
+      "type": "integer",
+      "displayName": "Content Stream Length"
+    },
+    "custom:invoiceNumber": {
+      "value": "INV-2026-001",
+      "type": "string",
+      "displayName": "Invoice Number"
+    },
+    "custom:amount": {
+      "value": 150000.00,
+      "type": "decimal",
+      "displayName": "Amount"
+    },
+    "custom:tags": {
+      "value": ["finance", "2026", "Q1"],
+      "type": "string",
+      "cardinality": "multi",
+      "displayName": "Tags"
+    }
+  }
+}
+```
+
+#### 3.3.3 プロパティ型マッピング
+
+| CMIS PropertyType | JSON 表現 | type 値 |
+|-------------------|-----------|---------|
+| string | string | "string" |
+| boolean | boolean | "boolean" |
+| integer | number (integer) | "integer" |
+| decimal | number | "decimal" |
+| datetime | string (ISO 8601) | "datetime" |
+| uri | string | "uri" |
+| id | string | "id" |
+| html | string | "html" |
+
+#### 3.3.4 動的スキーマ生成エンドポイント
+
+タイプ定義から OpenAPI スキーマを動的に生成するエンドポイントを提供：
+
+```
+GET /api/v1/repositories/{repositoryId}/types/{typeId}/schema
+```
+
+**レスポンス例:**
+```json
+{
+  "typeId": "custom:invoice",
+  "openApiSchema": {
+    "type": "object",
+    "properties": {
+      "objectId": {"type": "string"},
+      "objectTypeId": {"type": "string", "const": "custom:invoice"},
+      "properties": {
+        "type": "object",
+        "properties": {
+          "custom:invoiceNumber": {
+            "type": "object",
+            "properties": {
+              "value": {"type": "string"},
+              "type": {"type": "string", "const": "string"}
+            },
+            "required": ["value"]
+          },
+          "custom:amount": {
+            "type": "object",
+            "properties": {
+              "value": {"type": "number"},
+              "type": {"type": "string", "const": "decimal"}
+            },
+            "required": ["value"]
+          }
+        },
+        "required": ["custom:invoiceNumber", "custom:amount"]
+      }
+    }
+  }
+}
+```
+
+**SDK 生成ワークフロー:**
+1. `/types` エンドポイントでタイプ一覧を取得
+2. 各タイプの `/types/{typeId}/schema` でスキーマを取得
+3. 取得したスキーマを使用してタイプ固有の DTO を生成
+
+### 3.4 リソース設計
+
+#### 3.4.1 リポジトリ (`/api/v1/repositories`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/` | リポジトリ一覧取得 | getRepositoryInfos |
+| GET | `/{repositoryId}` | リポジトリ情報取得 | getRepositoryInfo |
+| GET | `/{repositoryId}/capabilities` | ケイパビリティ取得 | getRepositoryInfo |
+| GET | `/{repositoryId}/rootFolder` | ルートフォルダ取得 | - |
+
+#### 3.4.2 オブジェクト (`/api/v1/repositories/{repositoryId}/objects`)
+
+**正規エンドポイント** - 任意のオブジェクトタイプにアクセス可能
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/{objectId}` | オブジェクト取得 | getObject |
+| GET | `/byPath` | パスでオブジェクト取得 | getObjectByPath |
+| POST | `/` | オブジェクト作成 | create |
+| PUT | `/{objectId}` | プロパティ更新 | updateProperties |
+| PUT | `/bulk` | 一括プロパティ更新 | bulkUpdateProperties |
+| DELETE | `/{objectId}` | オブジェクト削除 | deleteObject |
+| POST | `/{objectId}/move` | オブジェクト移動 | moveObject |
+| GET | `/{objectId}/allowableActions` | 許可アクション取得 | getAllowableActions |
+| GET | `/{objectId}/content` | コンテンツストリーム取得 | getContentStream |
+| PUT | `/{objectId}/content` | コンテンツストリーム設定 | setContentStream |
+| DELETE | `/{objectId}/content` | コンテンツストリーム削除 | deleteContentStream |
+| POST | `/{objectId}/content/append` | コンテンツ追記 | appendContentStream |
+| GET | `/{objectId}/renditions` | レンディション取得 | getRenditions |
+| GET | `/{objectId}/parents` | 親オブジェクト取得 | getObjectParents |
+| GET | `/{objectId}/relationships` | リレーションシップ取得 | getObjectRelationships |
+
+#### 3.4.3 コンテンツストリーム操作
+
+##### PUT /objects/{objectId}/content - コンテンツ設定
+
+**リクエスト形式:**
+
+**方式1: Raw Binary（推奨）**
+```
+PUT /api/v1/repositories/{repoId}/objects/{objectId}/content
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="document.pdf"
+X-Overwrite-Flag: true
+X-Change-Token: {changeToken}
+
+[binary content]
+```
+
+**方式2: Multipart（メタデータ同時更新時）**
+```
+POST /api/v1/repositories/{repoId}/objects/{objectId}/content
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundary
+
+------WebKitFormBoundary
+Content-Disposition: form-data; name="file"; filename="document.pdf"
+Content-Type: application/pdf
+
+[binary content]
+------WebKitFormBoundary
+Content-Disposition: form-data; name="overwriteFlag"
+
+true
+------WebKitFormBoundary--
+```
+
+**レスポンス:**
+```json
+{
+  "objectId": "OBJECT_ID",
+  "changeToken": "NEW_CHANGE_TOKEN",
+  "contentStreamLength": 12345,
+  "contentStreamMimeType": "application/pdf",
+  "contentStreamFileName": "document.pdf"
+}
+```
+
+##### GET /objects/{objectId}/content - コンテンツ取得
+
+**レスポンスヘッダー:**
+```
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="document.pdf"
+Content-Length: 12345
+ETag: "CONTENT_HASH"
+```
+
+#### 3.4.4 フォルダ (`/api/v1/repositories/{repositoryId}/folders`)
+
+**便宜的エンドポイント** - フォルダ固有の操作とナビゲーション
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | フォルダ作成 | createFolder |
+| GET | `/{folderId}` | フォルダ取得 | getObject |
+| GET | `/{folderId}/children` | 子オブジェクト取得 | getChildren |
+| GET | `/{folderId}/descendants` | 子孫オブジェクト取得 | getDescendants |
+| GET | `/{folderId}/tree` | フォルダツリー取得 | getFolderTree |
+| GET | `/{folderId}/parent` | 親フォルダ取得 | getFolderParent |
+| DELETE | `/{folderId}/tree` | ツリー削除 | deleteTree |
+
+#### 3.4.5 ドキュメント (`/api/v1/repositories/{repositoryId}/documents`)
+
+**便宜的エンドポイント** - ドキュメント固有の操作（バージョニング）
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | ドキュメント作成 | createDocument |
+| POST | `/fromSource` | コピー作成 | createDocumentFromSource |
+| GET | `/{documentId}/versions` | 全バージョン取得 | getAllVersions |
+| GET | `/{documentId}/latestVersion` | 最新バージョン取得 | getObjectOfLatestVersion |
+| POST | `/{documentId}/checkout` | チェックアウト | checkOut |
+| POST | `/{documentId}/cancelCheckout` | チェックアウト取消 | cancelCheckOut |
+| POST | `/{documentId}/checkin` | チェックイン | checkIn |
+| GET | `/checkedout` | チェックアウト一覧 | getCheckedOutDocs |
+
+##### バージョニング操作のレスポンス仕様
+
+**POST /documents/{documentId}/checkout レスポンス:**
+
+チェックアウト操作は PWC (Private Working Copy) を作成し、その情報を返します。
+
+```json
+{
+  "pwcId": "PWC_OBJECT_ID",
+  "originalObjectId": "ORIGINAL_OBJECT_ID",
+  "versionSeriesId": "VERSION_SERIES_ID",
+  "versionSeriesCheckedOutId": "PWC_OBJECT_ID",
+  "versionSeriesCheckedOutBy": "admin",
+  "isVersionSeriesCheckedOut": true,
+  "_links": {
+    "pwc": {"href": "/api/v1/repositories/bedroom/objects/PWC_OBJECT_ID"},
+    "original": {"href": "/api/v1/repositories/bedroom/objects/ORIGINAL_OBJECT_ID"},
+    "checkin": {"href": "/api/v1/repositories/bedroom/documents/PWC_OBJECT_ID/checkin"}
+  }
+}
+```
+
+**POST /documents/{documentId}/checkin リクエスト:**
+
+```json
+{
+  "major": true,
+  "checkinComment": "Updated version with corrections",
+  "properties": {
+    "cmis:description": {"value": "Updated description"}
+  }
+}
+```
+
+**POST /documents/{documentId}/checkin レスポンス:**
+
+チェックイン操作は**新しいバージョンのオブジェクト情報**を返します。PWC ID は無効になります。
+
+```json
+{
+  "objectId": "NEW_VERSION_OBJECT_ID",
+  "versionSeriesId": "VERSION_SERIES_ID",
+  "versionLabel": "2.0",
+  "isMajorVersion": true,
+  "isLatestVersion": true,
+  "isLatestMajorVersion": true,
+  "checkinComment": "Updated version with corrections",
+  "previousVersionId": "PREVIOUS_VERSION_OBJECT_ID",
+  "properties": {},
+  "_links": {
+    "self": {"href": "/api/v1/repositories/bedroom/objects/NEW_VERSION_OBJECT_ID"},
+    "versionSeries": {"href": "/api/v1/repositories/bedroom/documents/VERSION_SERIES_ID/versions"},
+    "previousVersion": {"href": "/api/v1/repositories/bedroom/objects/PREVIOUS_VERSION_OBJECT_ID"},
+    "content": {"href": "/api/v1/repositories/bedroom/objects/NEW_VERSION_OBJECT_ID/content"}
+  }
+}
+```
+
+**POST /documents/{documentId}/cancelCheckout レスポンス:**
+
+```json
+{
+  "success": true,
+  "cancelledPwcId": "PWC_OBJECT_ID",
+  "restoredObjectId": "ORIGINAL_OBJECT_ID",
+  "versionSeriesId": "VERSION_SERIES_ID",
+  "isVersionSeriesCheckedOut": false,
+  "_links": {
+    "restoredObject": {"href": "/api/v1/repositories/bedroom/objects/ORIGINAL_OBJECT_ID"}
+  }
+}
+```
+
+#### 3.4.6 タイプ (`/api/v1/repositories/{repositoryId}/types`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/` | タイプ一覧取得 | getTypeChildren |
+| GET | `/{typeId}` | タイプ定義取得 | getTypeDefinition |
+| GET | `/{typeId}/children` | 子タイプ取得 | getTypeChildren |
+| GET | `/{typeId}/descendants` | 子孫タイプ取得 | getTypeDescendants |
+| GET | `/{typeId}/schema` | OpenAPI スキーマ取得 | - |
+| POST | `/` | タイプ作成 | createType |
+| PUT | `/{typeId}` | タイプ更新 | updateType |
+| DELETE | `/{typeId}` | タイプ削除 | deleteType |
+
+#### 3.4.7 ACL (`/api/v1/repositories/{repositoryId}/objects/{objectId}/acl`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| GET | `/` | ACL 取得 | getAcl |
+| PUT | `/` | ACL 適用 | applyAcl |
+
+#### 3.4.8 リレーションシップ (`/api/v1/repositories/{repositoryId}/relationships`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | リレーションシップ作成 | createRelationship |
+| GET | `/object/{objectId}` | オブジェクトのリレーションシップ取得 | getObjectRelationships |
+
+#### 3.4.9 ポリシー (`/api/v1/repositories/{repositoryId}/policies`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | ポリシー作成 | createPolicy |
+| POST | `/apply` | ポリシー適用 | applyPolicy |
+| POST | `/remove` | ポリシー解除 | removePolicy |
+| GET | `/object/{objectId}` | 適用ポリシー取得 | getAppliedPolicies |
+
+#### 3.4.10 クエリ (`/api/v1/repositories/{repositoryId}/query`)
+
+| メソッド | パス | 説明 | CMIS 対応 |
+|---------|------|------|-----------|
+| POST | `/` | CMIS クエリ実行 | query |
+| GET | `/changes` | 変更ログ取得 | getContentChanges |
+
+#### 3.4.11 ユーザー (`/api/v1/repositories/{repositoryId}/users`)
+
+既存の `/rest/repo/{repositoryId}/user/` と同等の機能を OpenAPI 準拠で再設計。
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/` | ユーザー一覧取得 |
+| GET | `/{userId}` | ユーザー取得 |
+| GET | `/search` | ユーザー検索 |
+| POST | `/` | ユーザー作成 |
+| PUT | `/{userId}` | ユーザー更新 |
+| DELETE | `/{userId}` | ユーザー削除 |
+| POST | `/{userId}/password` | パスワード変更 |
+
+#### 3.4.12 グループ (`/api/v1/repositories/{repositoryId}/groups`)
+
+既存の `/rest/repo/{repositoryId}/group/` と同等の機能を OpenAPI 準拠で再設計。
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/` | グループ一覧取得 |
+| GET | `/{groupId}` | グループ取得 |
+| GET | `/search` | グループ検索 |
+| POST | `/` | グループ作成 |
+| PUT | `/{groupId}` | グループ更新 |
+| DELETE | `/{groupId}` | グループ削除 |
+| POST | `/{groupId}/members` | メンバー追加 |
+| DELETE | `/{groupId}/members` | メンバー削除 |
+
+#### 3.4.13 認証 (`/api/v1/auth`)
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| POST | `/login` | ログイン（トークン発行） |
+| POST | `/logout` | ログアウト（トークン無効化） |
+| POST | `/token/refresh` | トークンリフレッシュ |
+| POST | `/saml` | SAML 認証 |
+| POST | `/oidc` | OIDC 認証 |
+| GET | `/me` | 現在のユーザー情報取得 |
+
+### 3.5 共通仕様
+
+#### 3.5.1 認証
+
+```
+Authorization: Bearer {token}
+```
+
+または
+
+```
+Authorization: Basic {base64(username:password)}
+```
+
+#### 3.5.2 エラーレスポンス
+
+RFC 7807 (Problem Details for HTTP APIs) 準拠:
+
+```json
+{
+  "type": "https://nemakiware.org/errors/object-not-found",
+  "title": "Object Not Found",
+  "status": 404,
+  "detail": "The object with ID 'OBJECT_ID' was not found in repository 'bedroom'",
+  "instance": "/api/v1/repositories/bedroom/objects/OBJECT_ID"
+}
+```
+
+**エラーコード一覧:**
+
+| HTTP Status | Type | 説明 |
+|-------------|------|------|
+| 400 | invalid-argument | 不正なリクエストパラメータ |
+| 401 | unauthorized | 認証が必要 |
+| 403 | permission-denied | 権限不足 |
+| 404 | object-not-found | オブジェクトが見つからない |
+| 404 | type-not-found | タイプが見つからない |
+| 409 | conflict | 競合（名前重複、バージョン競合など） |
+| 409 | content-already-exists | コンテンツが既に存在 |
+| 409 | version-conflict | バージョン競合（changeToken 不一致） |
+| 422 | constraint-violation | 制約違反 |
+| 500 | internal-error | 内部エラー |
+| 503 | service-unavailable | サービス利用不可 |
+
+#### 3.5.3 ページネーション
+
+```json
+{
+  "items": [],
+  "hasMoreItems": true,
+  "numItems": 1000,
+  "pageInfo": {
+    "maxItems": 50,
+    "skipCount": 0
+  },
+  "_links": {
+    "self": {"href": "...?maxItems=50&skipCount=0"},
+    "first": {"href": "...?maxItems=50&skipCount=0"},
+    "next": {"href": "...?maxItems=50&skipCount=50"},
+    "last": {"href": "...?maxItems=50&skipCount=950"}
+  }
+}
+```
+
+#### 3.5.4 HATEOAS リンク
+
+全てのリソースレスポンスに `_links` セクションを含める:
+
+```json
+{
+  "_links": {
+    "self": {"href": "/api/v1/repositories/bedroom/objects/OBJECT_ID"},
+    "parent": {"href": "/api/v1/repositories/bedroom/folders/PARENT_ID"},
+    "children": {"href": "/api/v1/repositories/bedroom/folders/OBJECT_ID/children"},
+    "content": {"href": "/api/v1/repositories/bedroom/objects/OBJECT_ID/content"},
+    "acl": {"href": "/api/v1/repositories/bedroom/objects/OBJECT_ID/acl"},
+    "type": {"href": "/api/v1/repositories/bedroom/types/cmis:document"}
+  }
+}
+```
+
+---
+
+## 4. OData 4.0 設計
+
+### 4.1 概要
+
+OData (Open Data Protocol) 4.0 は、RESTful API の上に構築された標準プロトコルで、データのクエリと操作を標準化します。NemakiWare では、コンテンツリポジトリへの柔軟なアクセスを提供するために OData をサポートします。
+
+### 4.2 OData スコープ定義
+
+#### 4.2.1 サポート範囲
+
+| 機能カテゴリ | サポートレベル | 備考 |
+|-------------|---------------|------|
+| 読み取り操作 | 完全サポート | GET によるエンティティ/コレクション取得 |
+| 作成操作 | 完全サポート | POST によるエンティティ作成 |
+| 更新操作 | 完全サポート | PUT/PATCH によるプロパティ更新 |
+| 削除操作 | 完全サポート | DELETE によるエンティティ削除 |
+| アクション | 部分サポート | CheckOut, CheckIn, Move, Copy |
+| ファンクション | 部分サポート | GetAllVersions, GetObjectByPath, Query |
+| バッチ操作 | 初期リリースでは未サポート | 将来バージョンで検討 |
+
+#### 4.2.2 制限事項
+
+1. **バッチ操作**: `$batch` エンドポイントは初期リリースでは未サポート
+2. **デルタクエリ**: `$deltatoken` は未サポート（代わりに CMIS の getContentChanges を使用）
+3. **非同期操作**: `Prefer: respond-async` は未サポート
+
+### 4.3 エンドポイント構造
+
+```
+/odata/{repositoryId}/              # サービスルート
+/odata/{repositoryId}/$metadata     # メタデータドキュメント
+/odata/{repositoryId}/{EntitySet}   # エンティティセット
+```
+
+### 4.4 動的メタデータ生成
+
+#### 4.4.1 設計方針
+
+OData の `$metadata` エンドポイントは、CMIS タイプ定義に基づいて**動的に生成**されます。これにより、カスタムタイプが OData クライアントから正しく認識されます。
+
+**動的生成の仕組み:**
+1. 基本タイプ（Document, Folder, Relationship, Policy, Item）は常に存在
+2. カスタムタイプは派生 EntityType として動的に追加
+3. タイプ定義の変更時にメタデータを再生成
+4. ETag ヘッダーによるキャッシュ制御
+
+#### 4.4.2 メタデータキャッシュ
+
+```
+GET /odata/bedroom/$metadata
+If-None-Match: "TYPE_HASH_123"
+```
+
+**レスポンスヘッダー:**
+```
+ETag: "TYPE_HASH_456"
+Cache-Control: private, max-age=3600
+```
+
+タイプ定義が変更されると ETag が更新され、クライアントは新しいメタデータを取得します。
+
+### 4.5 エンティティセット
+
+| エンティティセット | 説明 | 対応 CMIS タイプ |
+|-------------------|------|-----------------|
+| Objects | 全オブジェクト | cmis:object |
+| Documents | ドキュメント | cmis:document |
+| Folders | フォルダ | cmis:folder |
+| Relationships | リレーションシップ | cmis:relationship |
+| Policies | ポリシー | cmis:policy |
+| Items | アイテム | cmis:item |
+| Types | タイプ定義 | - |
+| Users | ユーザー | nemaki:user |
+| Groups | グループ | nemaki:group |
+
+### 4.6 クエリオプション
+
+| オプション | 説明 | 例 |
+|-----------|------|-----|
+| $filter | フィルタ条件 | `$filter=name eq 'test.pdf'` |
+| $select | 取得プロパティ | `$select=objectId,name,creationDate` |
+| $expand | 関連エンティティ展開 | `$expand=parent,children` |
+| $orderby | ソート | `$orderby=creationDate desc` |
+| $top | 取得件数制限 | `$top=10` |
+| $skip | スキップ件数 | `$skip=20` |
+| $count | 件数取得 | `$count=true` |
+| $search | 全文検索 | `$search=invoice` |
+
+### 4.7 検索仕様（$search と CMIS Query の関係）
+
+#### 4.7.1 検索機能の整理
+
+| 検索方法 | 用途 | 実装 | 対応 |
+|---------|------|------|------|
+| `$search` | 全文検索（キーワード） | Solr 全文検索 | OData 標準 |
+| `$filter` | プロパティベースフィルタ | CMIS WHERE 句に変換 | OData 標準 |
+| `Query()` ファンクション | CMIS SQL 完全サポート | CMIS Query 直接実行 | NemakiWare 拡張 |
+
+#### 4.7.2 $search の動作
+
+`$search` は Solr の全文検索を使用し、ドキュメントのコンテンツとプロパティを検索します。
+
+```
+GET /odata/bedroom/Documents?$search=contract
+```
+
+**内部処理:**
+1. Solr に全文検索クエリを発行
+2. マッチしたオブジェクト ID を取得
+3. CMIS からオブジェクト情報を取得
+4. OData 形式でレスポンスを返却
+
+#### 4.7.3 $filter の動作
+
+`$filter` は CMIS Query の WHERE 句に変換されます。
+
+```
+GET /odata/bedroom/Documents?$filter=contentStreamMimeType eq 'application/pdf' and creationDate gt 2026-01-01T00:00:00Z
+```
+
+**変換後の CMIS Query:**
+```sql
+SELECT * FROM cmis:document WHERE cmis:contentStreamMimeType = 'application/pdf' AND cmis:creationDate > TIMESTAMP '2026-01-01T00:00:00.000Z'
+```
+
+#### 4.7.4 Query() ファンクションの動作
+
+CMIS SQL を直接実行する場合は `Query()` ファンクションを使用します。
+
+```
+GET /odata/bedroom/Query(statement='SELECT * FROM cmis:document WHERE CONTAINS("contract")',searchAllVersions=false,maxItems=100)
+```
+
+### 4.8 ACL/権限の表現
+
+#### 4.8.1 権限チェックの動作
+
+OData は標準的に ACL を持たないため、NemakiWare では以下の動作を定義します。
+
+| シナリオ | HTTP Status | 動作 |
+|---------|-------------|------|
+| 特定オブジェクトへのアクセス権限なし | 403 Forbidden | エラーレスポンスを返却 |
+| オブジェクトが存在しない | 404 Not Found | エラーレスポンスを返却 |
+| コレクション取得時に権限のないオブジェクト | - | 結果から除外（エラーなし） |
+
+#### 4.8.2 コレクション取得時の権限フィルタ
+
+`$filter` や `$search` でコレクションを取得する場合、ユーザーが読み取り権限を持つオブジェクトのみが返されます。
+
+**レスポンスヘッダー:**
+```
+X-Total-Count: 150
+X-Accessible-Count: 120
+```
+
+- `X-Total-Count`: フィルタ条件にマッチした総件数（権限チェック前）
+- `X-Accessible-Count`: ユーザーがアクセス可能な件数
+
+**注意:** `X-Total-Count` は管理者のみに返却されます。一般ユーザーには `X-Accessible-Count` のみが返却されます。
+
+#### 4.8.3 権限エラーレスポンス
+
+```json
+{
+  "error": {
+    "code": "PermissionDenied",
+    "message": "You do not have permission to access this object",
+    "target": "Documents('OBJECT_ID')",
+    "details": [
+      {
+        "code": "InsufficientPermission",
+        "message": "Required permission: cmis:read"
+      }
+    ]
+  }
+}
+```
+
+### 4.9 アクションとファンクション
+
+#### 4.9.1 アクション（副作用あり）
+
+| アクション | 説明 | バインド先 |
+|-----------|------|-----------|
+| CheckOut | チェックアウト | Document |
+| CancelCheckOut | チェックアウト取消 | Document |
+| CheckIn | チェックイン | Document |
+| Move | 移動 | Object |
+| Copy | コピー | Document |
+| ApplyAcl | ACL 適用 | Object |
+
+**例:**
+```
+POST /odata/bedroom/Documents('OBJECT_ID')/NemakiWare.CMIS.CheckOut
+```
+
+#### 4.9.2 ファンクション（副作用なし）
+
+| ファンクション | 説明 | バインド先 |
+|---------------|------|-----------|
+| GetAllVersions | 全バージョン取得 | Document |
+| GetObjectByPath | パスでオブジェクト取得 | EntitySet |
+| Query | CMIS クエリ実行 | EntitySet |
+
+**例:**
+```
+GET /odata/bedroom/Documents('OBJECT_ID')/NemakiWare.CMIS.GetAllVersions()
+GET /odata/bedroom/GetObjectByPath(path='/folder/document.pdf')
+GET /odata/bedroom/Query(statement='SELECT * FROM cmis:document',maxItems=100)
+```
+
+---
+
+## 5. API 互換性ポリシー
+
+### 5.1 バージョニング方針
+
+#### 5.1.1 セマンティックバージョニング
+
+API バージョンは URL パスに含まれ、セマンティックバージョニングに従います。
+
+```
+/api/v1/...  # メジャーバージョン 1
+/api/v2/...  # メジャーバージョン 2（将来）
+```
+
+#### 5.1.2 バージョン間の互換性
+
+| 変更タイプ | 互換性 | 例 |
+|-----------|--------|-----|
+| 新規エンドポイント追加 | 後方互換 | 新しいリソースの追加 |
+| 新規オプションパラメータ追加 | 後方互換 | クエリパラメータの追加 |
+| 新規レスポンスフィールド追加 | 後方互換 | JSON フィールドの追加 |
+| 必須パラメータの追加 | 破壊的変更 | メジャーバージョンアップ必要 |
+| エンドポイントの削除 | 破壊的変更 | メジャーバージョンアップ必要 |
+| レスポンス形式の変更 | 破壊的変更 | メジャーバージョンアップ必要 |
+
+### 5.2 非推奨ポリシー
+
+#### 5.2.1 非推奨の通知
+
+非推奨となった機能は、レスポンスヘッダーで通知されます。
+
+```
+Deprecation: true
+Sunset: Sat, 01 Jan 2028 00:00:00 GMT
+Link: </api/v2/...>; rel="successor-version"
+```
+
+#### 5.2.2 非推奨期間
+
+- 非推奨から削除まで: 最低 2 メジャーリリース（約 12 ヶ月）
+- 非推奨期間中は機能は維持される
+- 削除予定日は `Sunset` ヘッダーで通知
+
+### 5.3 既存 REST API との互換性
+
+#### 5.3.1 互換性方針
+
+**明確な方針: `/rest/` と `/api/v1/` は互換性なし**
+
+| 項目 | `/rest/` (既存) | `/api/v1/` (新規) |
+|------|----------------|-------------------|
+| レスポンス形式 | 独自形式 | OpenAPI 準拠 |
+| エラー形式 | 独自形式 | RFC 7807 準拠 |
+| プロパティ表現 | フラット | 2層構造（value/type） |
+| ページネーション | 独自形式 | 標準形式 |
+
+#### 5.3.2 移行サポート
+
+1. `/rest/` エンドポイントは維持（非推奨化なし）
+2. 新規開発は `/api/v1/` を推奨
+3. 移行ガイドを提供（セクション 8 参照）
+
+---
+
+## 6. OpenAPI スキーマ戦略
+
+### 6.1 スキーマ設計方針
+
+#### 6.1.1 基本タイプのスキーマ
+
+CMIS 標準タイプ（cmis:document, cmis:folder 等）は静的スキーマとして定義します。
+
+```yaml
+components:
+  schemas:
+    CmisObject:
+      type: object
+      required:
+        - objectId
+        - objectTypeId
+        - baseTypeId
+      properties:
+        objectId:
+          type: string
+        objectTypeId:
+          type: string
+        baseTypeId:
+          type: string
+        properties:
+          $ref: '#/components/schemas/PropertyMap'
+        allowableActions:
+          $ref: '#/components/schemas/AllowableActions'
+        _links:
+          $ref: '#/components/schemas/Links'
+
+    PropertyMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/PropertyValue'
+
+    PropertyValue:
+      type: object
+      required:
+        - value
+        - type
+      properties:
+        value:
+          oneOf:
+            - type: string
+            - type: number
+            - type: boolean
+            - type: array
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+                  - type: boolean
+        type:
+          type: string
+          enum:
+            - string
+            - boolean
+            - integer
+            - decimal
+            - datetime
+            - uri
+            - id
+            - html
+        displayName:
+          type: string
+        cardinality:
+          type: string
+          enum:
+            - single
+            - multi
+```
+
+#### 6.1.2 カスタムタイプのスキーマ
+
+カスタムタイプは動的スキーマ生成エンドポイントで取得します。
+
+```
+GET /api/v1/repositories/{repositoryId}/types/{typeId}/schema
+```
+
+### 6.2 SDK 生成における不確実性の取り扱い
+
+#### 6.2.1 推奨ワークフロー
+
+1. **静的 SDK 生成**: 基本 OpenAPI 仕様から SDK を生成
+2. **動的型情報取得**: 実行時にタイプ定義 API から型情報を取得
+3. **型安全なアクセス**: 取得した型情報を使用してプロパティにアクセス
+
+#### 6.2.2 SDK 生成時の注意事項
+
+```yaml
+# openapi.yaml での注釈
+x-nemakiware-dynamic-properties:
+  description: |
+    The 'properties' field contains dynamic properties based on the object's type.
+    Use the /types/{typeId}/schema endpoint to get the exact schema for a specific type.
+    SDK generators should treat this as a generic map and provide helper methods
+    for type-safe property access.
+```
+
+---
+
+## 7. 実装計画
+
+### 7.1 技術スタック
+
+| コンポーネント | 技術 | 備考 |
+|---------------|------|------|
+| REST フレームワーク | Jersey (JAX-RS) | 既存と同じ |
+| OpenAPI 生成 | Swagger/OpenAPI 3.0 | swagger-jaxrs2 |
+| OData ライブラリ | Apache Olingo 4.x | OData 4.0 対応 |
+| JSON 処理 | Jackson | 既存と同じ |
+| ドキュメント UI | Swagger UI | API ドキュメント |
+| REST テスト | REST Assured | 流暢な API テスト |
+| OData テスト | Apache Olingo Client | OData クライアントテスト |
+| API 仕様検証 | Swagger Request Validator | OpenAPI 仕様との整合性検証 |
+
+### 7.2 フェーズ分け
+
+#### フェーズ 1: OpenAPI 基盤整備（2-3週間）
+
+1. OpenAPI 3.0 仕様ファイル（openapi.yaml）の作成
+2. Swagger UI の統合
+3. 共通エラーハンドリングの実装
+4. 認証フィルタの整備
+5. プロパティ 2 層構造の DTO 実装
+
+#### フェーズ 2: CMIS 操作の REST 化（4-6週間）
+
+1. ObjectService の REST 化
+   - オブジェクト CRUD
+   - コンテンツストリーム操作（Raw Binary / Multipart 対応）
+2. NavigationService の REST 化
+   - フォルダナビゲーション
+3. VersioningService の REST 化
+   - チェックアウト/チェックイン（レスポンス形式の明確化）
+4. DiscoveryService の REST 化
+   - クエリ実行
+5. その他サービスの REST 化
+
+#### フェーズ 3: OData 対応（3-4週間）
+
+1. Apache Olingo の統合
+2. 動的メタデータ生成の実装
+3. OData サービスプロバイダの実装
+4. クエリオプションの実装（$filter → CMIS Query 変換）
+5. $search と Solr の統合
+6. アクション/ファンクションの実装
+7. 権限フィルタの実装
+
+#### フェーズ 4: テストと文書化（2-3週間）
+
+1. 単体テスト
+2. 統合テスト
+3. OData 準拠テスト（セクション 9 参照）
+4. API ドキュメントの完成
+5. マイグレーションガイドの作成
+
+### 7.3 ディレクトリ構造
+
+```
+core/src/main/java/jp/aegif/nemaki/
+├── api/                          # 新規 OpenAPI REST API
+│   ├── v1/
+│   │   ├── ApiApplication.java   # JAX-RS Application
+│   │   ├── resource/
+│   │   │   ├── RepositoryResource.java
+│   │   │   ├── ObjectResource.java
+│   │   │   ├── FolderResource.java
+│   │   │   ├── DocumentResource.java
+│   │   │   ├── TypeResource.java
+│   │   │   ├── AclResource.java
+│   │   │   ├── QueryResource.java
+│   │   │   ├── UserResource.java
+│   │   │   ├── GroupResource.java
+│   │   │   └── AuthResource.java
+│   │   ├── model/
+│   │   │   ├── PropertyValue.java    # 2層構造プロパティ
+│   │   │   ├── request/              # リクエスト DTO
+│   │   │   └── response/             # レスポンス DTO
+│   │   ├── filter/
+│   │   │   ├── AuthenticationFilter.java
+│   │   │   └── CorsFilter.java
+│   │   └── exception/
+│   │       ├── ApiExceptionMapper.java
+│   │       └── ProblemDetail.java
+│   └── odata/
+│       ├── ODataServlet.java
+│       ├── NemakiEdmProvider.java        # 動的メタデータ生成
+│       ├── NemakiEntityCollectionProcessor.java
+│       ├── NemakiEntityProcessor.java
+│       ├── NemakiActionProcessor.java
+│       ├── NemakiSearchHandler.java      # $search 処理
+│       └── NemakiPermissionFilter.java   # 権限フィルタ
+├── rest/                         # 既存 REST API（維持）
+├── cmis/                         # 既存 CMIS 実装
+└── businesslogic/                # ビジネスロジック
+```
+
+---
+
+## 8. 移行ガイドライン
+
+### 8.1 既存 REST API からの移行
+
+#### 8.1.1 エンドポイントマッピング
+
+| 既存パス | 新規パス | 変更点 |
+|---------|---------|--------|
+| `/rest/repo/{repoId}/user/list` | `/api/v1/repositories/{repoId}/users` | GET メソッド、レスポンス形式 |
+| `/rest/repo/{repoId}/user/show/{id}` | `/api/v1/repositories/{repoId}/users/{id}` | パス構造 |
+| `/rest/repo/{repoId}/user/create/{id}` | `/api/v1/repositories/{repoId}/users` | POST メソッド、ID は自動生成可 |
+| `/rest/repo/{repoId}/group/list` | `/api/v1/repositories/{repoId}/groups` | GET メソッド、レスポンス形式 |
+| `/rest/repo/{repoId}/type/list` | `/api/v1/repositories/{repoId}/types` | GET メソッド、レスポンス形式 |
+| `/rest/repo/{repoId}/node/{id}/acl` | `/api/v1/repositories/{repoId}/objects/{id}/acl` | パス構造 |
+
+#### 8.1.2 レスポンス形式の変更
+
+**既存 REST API:**
+```json
+{
+  "status": "success",
+  "user": {
+    "userId": "user1",
+    "userName": "User One",
+    "email": "user1@example.com"
+  }
+}
+```
+
+**新規 REST API:**
+```json
+{
+  "userId": "user1",
+  "userName": "User One",
+  "email": "user1@example.com",
+  "_links": {
+    "self": {"href": "/api/v1/repositories/bedroom/users/user1"}
+  }
+}
+```
+
+### 8.2 CMIS バインディングからの移行
+
+CMIS Browser Binding と新規 REST API の対応:
+
+| CMIS Browser Binding | 新規 REST API |
+|---------------------|---------------|
+| `GET /browser/{repoId}/root?cmisselector=children` | `GET /api/v1/repositories/{repoId}/folders/{folderId}/children` |
+| `POST /browser/{repoId}?cmisaction=createDocument` | `POST /api/v1/repositories/{repoId}/documents` |
+| `GET /browser/{repoId}/root?cmisselector=object&objectId=xxx` | `GET /api/v1/repositories/{repoId}/objects/{objectId}` |
+| `POST /browser/{repoId}?cmisaction=checkOut&objectId=xxx` | `POST /api/v1/repositories/{repoId}/documents/{documentId}/checkout` |
+| `POST /browser/{repoId}?cmisaction=checkIn&objectId=xxx` | `POST /api/v1/repositories/{repoId}/documents/{documentId}/checkin` |
+| `POST /browser/{repoId}?cmisaction=query` | `POST /api/v1/repositories/{repoId}/query` |
+
+### 8.3 後方互換性
+
+- 既存の `/rest/` エンドポイントは維持（非推奨化なし）
+- 既存の CMIS バインディング（`/atom/`, `/browser/`）は維持
+- 新規開発は `/api/v1/` を推奨
+
+---
+
+## 9. テスト計画
+
+### 9.1 単体テスト
+
+- 各 Resource クラスのテスト
+- DTO 変換のテスト（特にプロパティ 2 層構造）
+- バリデーションのテスト
+- エラーハンドリングのテスト
+
+### 9.2 統合テスト
+
+- エンドツーエンドの API テスト
+- 認証・認可のテスト
+- OData クエリのテスト
+- コンテンツストリーム操作のテスト
+
+### 9.3 OData 準拠テスト
+
+#### 9.3.1 テスト戦略
+
+OData には CMIS TCK のような単一公式 TCK がないため、以下の戦略でテストを実施します。
+
+#### 9.3.2 $metadata 検証
+
+1. **スキーマ検証**: OData CSDL スキーマに対する検証
+2. **動的生成検証**: カスタムタイプ追加後のメタデータ再生成確認
+3. **ETag 検証**: キャッシュ制御の動作確認
+
+```java
+@Test
+void testMetadataValidation() {
+    // $metadata を取得
+    String metadata = client.getMetadata();
+    
+    // OData CSDL スキーマに対して検証
+    CsdlValidator.validate(metadata);
+    
+    // 必須要素の存在確認
+    assertContains(metadata, "EntityType Name=\"Document\"");
+    assertContains(metadata, "EntitySet Name=\"Documents\"");
+}
+```
+
+#### 9.3.3 クエリオプションテスト
+
+| テスト項目 | テスト内容 |
+|-----------|-----------|
+| $filter | 各演算子（eq, ne, gt, lt, contains 等）の動作確認 |
+| $select | プロパティ選択の動作確認 |
+| $expand | ナビゲーションプロパティ展開の動作確認 |
+| $orderby | ソート（昇順/降順）の動作確認 |
+| $top/$skip | ページネーションの動作確認 |
+| $count | 件数取得の動作確認 |
+| $search | 全文検索の動作確認 |
+
+```java
+@Test
+void testFilterOperators() {
+    // eq 演算子
+    var result = client.get("/odata/bedroom/Documents?$filter=name eq 'test.pdf'");
+    assertEquals(1, result.getValue().size());
+    
+    // contains 演算子
+    result = client.get("/odata/bedroom/Documents?$filter=contains(name,'test')");
+    assertTrue(result.getValue().size() > 0);
+    
+    // 複合条件
+    result = client.get("/odata/bedroom/Documents?$filter=name eq 'test.pdf' and creationDate gt 2026-01-01T00:00:00Z");
+    // ...
+}
+```
+
+#### 9.3.4 結果整合性テスト
+
+OData API と既存 CMIS/REST API の結果を比較し、整合性を確認します。
+
+```java
+@Test
+void testResultConsistency() {
+    // OData で取得
+    var odataResult = odataClient.get("/odata/bedroom/Documents('DOC_ID')");
+    
+    // CMIS で取得
+    var cmisResult = cmisSession.getObject("DOC_ID");
+    
+    // プロパティの整合性確認
+    assertEquals(cmisResult.getName(), odataResult.getProperty("name"));
+    assertEquals(cmisResult.getCreatedBy(), odataResult.getProperty("createdBy"));
+}
+```
+
+#### 9.3.5 OData クライアントライブラリテスト
+
+複数の OData クライアントライブラリでの動作確認:
+
+1. **Simple.OData.Client** (.NET)
+2. **Apache Olingo Client** (Java)
+3. **datajs** (JavaScript)
+
+### 9.4 互換性テスト
+
+- 既存 REST API との互換性（並行稼働確認）
+- CMIS TCK との互換性（既存機能の維持確認）
+
+---
+
+## 10. セキュリティ考慮事項
+
+### 10.1 認証
+
+1. **Bearer Token 認証**: JWT ベースのトークン認証
+2. **Basic 認証**: 後方互換性のため維持
+3. **SAML/OIDC**: エンタープライズ SSO 対応
+
+### 10.2 認可
+
+1. **CMIS ACL**: オブジェクトレベルのアクセス制御
+2. **API レベル認可**: 管理者専用エンドポイントの保護
+3. **リポジトリアクセス制御**: リポジトリ単位のアクセス制限
+
+### 10.3 入力検証
+
+1. **パラメータ検証**: OpenAPI スキーマに基づく検証
+2. **CMIS 制約チェック**: タイプ定義に基づく検証
+3. **サニタイズ**: XSS/インジェクション対策
+
+### 10.4 レート制限
+
+1. **API レート制限**: 過負荷防止
+2. **クエリ制限**: 大量データ取得の制限
+
+---
+
+## 11. 変更履歴
+
+| バージョン | 日付 | 変更内容 | 作成者 |
+|-----------|------|---------|--------|
+| 1.0 | 2026-01-19 | 初版作成 | Devin |
+| 1.1 | 2026-01-19 | レビューフィードバック反映 | Devin |
+|     |            | - プロパティ 2 層構造の明確化 |  |
+|     |            | - Object/Document/Folder 境界の整理 |  |
+|     |            | - バージョニングレスポンス形式の明確化 |  |
+|     |            | - Content Stream 形式の明確化 |  |
+|     |            | - OData 動的メタデータ生成の追加 |  |
+|     |            | - OData 権限処理の明確化 |  |
+|     |            | - $search と CMIS Query の関係整理 |  |
+|     |            | - 移行互換性ポリシーの明確化 |  |
+|     |            | - OData テスト戦略の具体化 |  |
+|     |            | - API 互換性ポリシーセクション追加 |  |
+|     |            | - OData スコープ定義セクション追加 |  |
+|     |            | - OpenAPI スキーマ戦略セクション追加 |  |
+|     |            | - テストツール（REST Assured, Olingo Client）追加 |  |
+
+---
+
+*本設計書は NemakiWare プロジェクトの一部として GNU AGPL v3 ライセンスの下で公開されます。*


### PR DESCRIPTION
### Motivation
- `SimpleDateFormat` はスレッドセーフでないため、API v1 の日時パースで並行アクセス時に不正な変換や例外が発生する可能性がありました。 

### Description
- `RelationshipResource` と `PolicyResource` の日時パース箇所で `ISO_DATE_FORMAT.parse(...)` を `synchronized (ISO_DATE_FORMAT) { ... }` で保護して `ISO_DATE_FORMAT` への並行アクセスを防止しました（変更ファイル: `core/src/main/java/jp/aegif/nemaki/api/v1/resource/RelationshipResource.java`, `core/src/main/java/jp/aegif/nemaki/api/v1/resource/PolicyResource.java`）。

### Testing
- 自動化テストは実行しておらず、今回の修正はコード上の競合回避に限定した軽微な変更です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d906848e48322abf0ce841ebc6698)