### PR TITLE
fix(ingest): id 欠落のリクエストが 500 (NPE) になっていたのを 404 に

### DIFF
--- a/core/src/main/java/jp/aegif/nemaki/rest/ingest/ConnectorDefinitionServiceImpl.java
+++ b/core/src/main/java/jp/aegif/nemaki/rest/ingest/ConnectorDefinitionServiceImpl.java
@@ -46,6 +46,11 @@ public class ConnectorDefinitionServiceImpl implements ConnectorDefinitionServic
 
     @Override
     public ConnectorDefinition get(String connectorId) {
+        // Null means "no such connector", not a crash: Map.of rejects null values with an NPE,
+        // so an ingest request that simply omits connectorId used to answer 500 with a stack
+        // trace, while a WRONG id answered a clean 404. Callers already treat null as
+        // not-found. findBySystemAndArchetype below has guarded this way all along.
+        if (connectorId == null) return null;
         List<ConnectorDefinition> results = findBySelector(Map.of(
                 "type", ConnectorDefinition.DOC_TYPE,
                 "connectorId", connectorId));

--- a/core/src/main/java/jp/aegif/nemaki/rest/ingest/ImportProfileDefinitionServiceImpl.java
+++ b/core/src/main/java/jp/aegif/nemaki/rest/ingest/ImportProfileDefinitionServiceImpl.java
@@ -51,6 +51,8 @@ public class ImportProfileDefinitionServiceImpl implements ImportProfileDefiniti
 
     @Override
     public ImportProfileDefinition get(String profileId) {
+        // Null means "no such profile", not a crash — see ConnectorDefinitionServiceImpl.get.
+        if (profileId == null) return null;
         List<ImportProfileDefinition> results = findBySelector(Map.of(
                 "type", ImportProfileDefinition.DOC_TYPE,
                 "profileId", profileId));

--- a/core/src/test/java/jp/aegif/nemaki/rest/ingest/IngestDefinitionLookupNullIdTest.java
+++ b/core/src/test/java/jp/aegif/nemaki/rest/ingest/IngestDefinitionLookupNullIdTest.java
@@ -1,0 +1,42 @@
+package jp.aegif.nemaki.rest.ingest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A MISSING id must mean "not found", never a crash.
+ *
+ * <p>Found while measuring the ingest path (2026-08-18): {@code POST /v1/repo/{repo}/ingest}
+ * answered <b>HTTP 500 with a stack trace</b> when the request simply omitted
+ * {@code profileId} or {@code connectorId}, while a request carrying a <i>wrong</i> id
+ * answered a clean 404. The cause was {@code Map.of(...)}, which rejects null values with an
+ * NPE — thrown one line before the caller's own {@code if (x == null) return error(...)}
+ * branch could ever run. {@code findBySystemAndArchetype} in the same class had guarded
+ * against exactly this all along; the two {@code get} methods were the outliers.
+ *
+ * <p>These tests reach the defect without any CouchDB: the NPE fires inside {@code Map.of}
+ * before the selector query touches a client, so an unwired instance is enough. Revert either
+ * guard and the corresponding test fails with NPE instead of passing.
+ */
+class IngestDefinitionLookupNullIdTest {
+
+    @Test
+    @DisplayName("ConnectorDefinitionServiceImpl.get(null) returns null instead of throwing")
+    void connectorLookupTreatsNullIdAsNotFound() {
+        ConnectorDefinitionServiceImpl service = new ConnectorDefinitionServiceImpl();
+
+        assertNull(service.get(null),
+                "a missing connectorId must resolve to not-found, so the caller can answer 400/404");
+    }
+
+    @Test
+    @DisplayName("ImportProfileDefinitionServiceImpl.get(null) returns null instead of throwing")
+    void profileLookupTreatsNullIdAsNotFound() {
+        ImportProfileDefinitionServiceImpl service = new ImportProfileDefinitionServiceImpl();
+
+        assertNull(service.get(null),
+                "a missing profileId must resolve to not-found, so the caller can answer 400/404");
+    }
+}


### PR DESCRIPTION
## 何が起きていたか

`POST /core/api/v1/repo/{repositoryId}/ingest` が `profileId` または `connectorId` を**省略した**リクエストに対して **HTTP 500 + スタックトレース**を返していました。id が**間違っている**場合は綺麗に 404 を返すので、「欠落だけが 500」という歪んだ挙動です。

```
java.lang.NullPointerException
  at ConnectorDefinitionServiceImpl.get(ConnectorDefinitionServiceImpl.java:49)
  at CanonicalImportServiceImpl.execute(CanonicalImportServiceImpl.java:1035)
  at ExternalIngestController.doIngest(ExternalIngestController.java:180)
```

原因は `Map.of` が null 値を NPE で拒否すること。呼び出し側には

```java
ConnectorDefinition connector = connectorDefinitionService.get(request.getConnectorId());
if (connector == null) {
    return ExternalIngestResult.error(requestId, "Connector not found: " + request.getConnectorId());
}
```

という**正しい分岐が既にある**のに、その 1 行手前のセレクタ構築で落ちていました。同じクラスの `findBySystemAndArchetype` は最初から `if (sourceSystem == null || archetype == null) return null;` を持っており、**2 つの `get()` だけが例外**でした。

## 修正

`get(null)` → `null` (= not found) の 1 行ガードを 2 箇所。呼び出し側は元から null を not-found として扱うので、外から見た変更は **500 が 404 になる**だけです。

## 検証

**判別テスト** `IngestDefinitionLookupNullIdTest` (2 件)。NPE は `Map.of` で発火しクライアントに到達する前に落ちるため、**CouchDB 不要**で欠陥に届きます。

**負のコントロール**: ガードを外すと 2 件とも `NullPointerException` で失敗することを確認済み。

**実機検証** (nb33 に v3.3.1 + 本修正の WAR をデプロイ):

| ケース | 修正前 | 修正後 |
|---|---|---|
| profileId 欠落 | 500 | **404** `Import profile not found: null` |
| connectorId 欠落 | 500 | **404** `Connector not found: null` |
| 両方欠落 | 500 | **404** |
| 不正な profileId (対照) | 404 | 404 (不変) |
| 正常系 | success:true | success:true (不変) |

サーバログの NPE **0 件**。ingest 関連テスト **406 件全緑**。

## 発見の経緯

3.4 の P0 実測 (`lineage.mode=journaled` のオーバーヘッド計測) で ingest 経路を叩いていて踏みました。同じ実測で「**通常の CMIS 作成経路は lineage を一切出さない** (emitter は ingest / retention / import-export / cloud-drive / archive 経路のみ)」という事実も判明しており、そちらは [`authenticity-roadmap.md`](docs/design/authenticity-roadmap.md) §9-2 に記録します (別 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)